### PR TITLE
fix(ci): disable crates.io publishing until v1.0.0

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,6 +2,8 @@
 # https://release-plz.dev/docs/config
 
 [workspace]
+# Disable crates.io publishing until v1.0.0
+publish = false
 # Disable changelog generation (re-enable after first release)
 changelog_update = false
 # Create GitHub releases


### PR DESCRIPTION
## Summary
- Adds `publish = false` to `release-plz.toml` workspace config
- Fixes CI failure where release-plz attempts to publish to crates.io without `CARGO_REGISTRY_TOKEN`

## Test Plan
- [ ] CI passes
- [ ] release-plz workflow no longer attempts crates.io publish

## Related
- Fixes https://github.com/Anveio/apm2/actions/runs/21269354337

🤖 Generated with [Claude Code](https://claude.com/claude-code)