### PR TITLE
docs(agents): add pointers to standards, templates, and PRD indexes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,31 @@
 See @CONTRIBUTING.md on how to work within this software project.
 
-Coding guidelines under @documents/coding
+## Coding & Process
 
-Release process documented under @documents/releases
+- Coding guidelines: @documents/coding
+- Release process: @documents/releases
+- IMPORTANT - Security invariants: @documents/security
 
-IMPORTANT: Security invariants documented under @documents/security
+## Standards & Schemas
+
+- Schema definitions: @standards/schemas/
+- Enum definitions: @standards/enums/
+- Lint specification: @standards/lint/LINT_SPEC.yaml
+- Standards index: @standards/00_standards_meta.yaml
+
+## Document Templates
+
+- PRD template (v2): @prd/template/
+- RFC template (v2): @rfc/template/
+- Engineering tickets: @work/templates/
+
+## Protocol Profiles
+
+- Protocol profile index: @protocol_profiles/README.yaml
+- AIP profile: @protocol_profiles/aip/AIP_PROFILE_V1.yaml
+
+## Active PRDs
+
+- AIP-0001 (gRPC Foundation): @documents/prds/AIP-0001/
+  - Requirements: @documents/prds/AIP-0001/requirements/
+  - Evidence artifacts: @documents/prds/AIP-0001/evidence_artifacts/


### PR DESCRIPTION
## Summary
- Add standards/schemas and enums references
- Add PRD and RFC template pointers
- Add protocol profiles reference
- Add AIP-0001 PRD with requirements and evidence directories

## Test plan
- [x] Documentation only change
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)