### PR TITLE
fix: add missing require_code_owner_review parameter to ruleset

### DIFF
--- a/.github/rulesets/protect-main.json
+++ b/.github/rulesets/protect-main.json
@@ -14,6 +14,7 @@
       "parameters": {
         "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_review_thread_resolution": true
       }


### PR DESCRIPTION
## Summary
- Adds the required `require_code_owner_review` parameter to the ruleset JSON schema

This parameter is required by the GitHub API but was missing from the initial commit.

## Test plan
- [x] Ruleset already applied and working via API
- [ ] Verify JSON file matches applied ruleset

🤖 Generated with [Claude Code](https://claude.com/claude-code)