### PR TITLE
ci: add auto-approve workflow for PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,50 @@
+# Auto-approve PRs when CI passes
+# Requires a PAT with repo scope stored as AUTO_APPROVE_PAT secret
+
+name: Auto Approve
+
+on:
+  # Trigger when CI workflow completes
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  auto-approve:
+    name: Auto Approve PR
+    runs-on: ubuntu-24.04
+    # Only run if CI succeeded and it was a PR
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Get PR number
+        id: pr
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:${context.payload.workflow_run.head_branch}`
+            });
+            if (pullRequests.length > 0) {
+              return pullRequests[0].number;
+            }
+            return null;
+          result-encoding: string
+
+      - name: Approve PR
+        if: steps.pr.outputs.result != 'null'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          github-token: ${{ secrets.AUTO_APPROVE_PAT }}
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ steps.pr.outputs.result }},
+              event: 'APPROVE',
+              body: '✅ Auto-approved: CI checks passed'
+            });


### PR DESCRIPTION
## Summary
- Adds GitHub Action that auto-approves PRs when CI passes
- Enables solo developers to satisfy review requirements while keeping CI enforcement

## Setup Required
Create a Personal Access Token (PAT) and add it as a repository secret:

1. Go to https://github.com/settings/tokens?type=beta (Fine-grained tokens)
2. Create token with:
   - **Repository access**: Only select repositories → `Anveio/apm2`
   - **Permissions**: Pull requests → Read and write
3. Go to https://github.com/Anveio/apm2/settings/secrets/actions
4. Add secret named `AUTO_APPROVE_PAT` with the token value

## How it works
1. CI workflow runs on PR
2. When CI succeeds, `workflow_run` event triggers auto-approve
3. Auto-approve workflow uses PAT to submit approval review
4. PR can now be merged (CI passed + review requirement satisfied)

## Test plan
- [ ] Create PAT with pull request write permissions
- [ ] Add `AUTO_APPROVE_PAT` secret to repository
- [ ] Merge this PR manually (first time)
- [ ] Future PRs will be auto-approved when CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)