### PR TITLE
feat(ledger): implement SQLite storage layer with WAL mode (TCK-00001)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,9 +123,11 @@ dependencies = [
  "once_cell",
  "proptest",
  "regex",
+ "rusqlite",
  "secrecy",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",
@@ -443,6 +457,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,9 +522,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -549,7 +593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -624,6 +668,17 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -770,6 +825,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -963,6 +1024,20 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustix"
@@ -1370,6 +1445,18 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,9 +61,13 @@ once_cell = "1.19"
 
 # Testing
 proptest = "1.0"
+tempfile = "3.10"
 
 # Benchmarking
 criterion = { version = "0.5", features = ["html_reports"] }
+
+# Database
+rusqlite = { version = "0.31", features = ["bundled"] }
 
 # Internal crates
 apm2-core = { version = "0.1.0", path = "crates/apm2-core" }

--- a/crates/apm2-core/Cargo.toml
+++ b/crates/apm2-core/Cargo.toml
@@ -45,9 +45,13 @@ humantime.workspace = true
 regex.workspace = true
 once_cell.workspace = true
 
+# Database
+rusqlite.workspace = true
+
 [dev-dependencies]
 proptest.workspace = true
 criterion.workspace = true
+tempfile.workspace = true
 
 [features]
 default = []

--- a/crates/apm2-core/src/ledger/mod.rs
+++ b/crates/apm2-core/src/ledger/mod.rs
@@ -1,0 +1,45 @@
+//! Ledger storage layer for the APM2 kernel.
+//!
+//! This module provides an append-only event ledger backed by `SQLite` with WAL
+//! mode for efficient concurrent reads. The ledger stores all kernel events in
+//! sequence and maintains references to artifacts stored in the
+//! content-addressable storage.
+//!
+//! # Features
+//!
+//! - **Append-only semantics**: Events can only be added, never modified or
+//!   deleted
+//! - **Cursor-based reads**: Efficient iteration through events by sequence
+//!   number
+//! - **WAL mode**: Concurrent read access while writes are in progress
+//! - **Artifact references**: Links to content-addressable storage for large
+//!   payloads
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use apm2_core::ledger::{EventRecord, Ledger};
+//!
+//! # fn example() -> Result<(), apm2_core::ledger::LedgerError> {
+//! let ledger = Ledger::open("/path/to/ledger.db")?;
+//!
+//! // Append an event
+//! let event = EventRecord::new(
+//!     "session.start",
+//!     "session-123",
+//!     b"{\"user\": \"alice\"}".to_vec(),
+//! );
+//! let seq_id = ledger.append(&event)?;
+//!
+//! // Read events from a cursor
+//! let events = ledger.read_from(0, 100)?;
+//! # Ok(())
+//! # }
+//! ```
+
+mod storage;
+
+#[cfg(test)]
+mod tests;
+
+pub use storage::{ArtifactRef, EventRecord, Ledger, LedgerError, LedgerStats};

--- a/crates/apm2-core/src/ledger/schema.sql
+++ b/crates/apm2-core/src/ledger/schema.sql
@@ -1,0 +1,83 @@
+-- APM2 Ledger Schema
+-- Implements append-only event storage with WAL mode for concurrent reads
+
+-- Enable WAL mode for better concurrent read performance
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA foreign_keys = ON;
+
+-- Events table: append-only ledger of all kernel events
+-- Each event has a monotonic sequence number for ordering
+CREATE TABLE IF NOT EXISTS events (
+    -- Auto-incrementing sequence number (monotonic, gap-free)
+    seq_id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+    -- Event type identifier (e.g., "session.start", "tool.request")
+    event_type TEXT NOT NULL,
+
+    -- Session identifier this event belongs to
+    session_id TEXT NOT NULL,
+
+    -- Event payload as JSON (flexible schema per event type)
+    payload BLOB NOT NULL,
+
+    -- Timestamp when event was recorded (nanoseconds since Unix epoch)
+    timestamp_ns INTEGER NOT NULL,
+
+    -- Hash of the previous event (for hash chaining in TCK-00003)
+    -- NULL for the first event in the ledger
+    prev_hash BLOB,
+
+    -- Hash of this event's content (computed in TCK-00003)
+    event_hash BLOB,
+
+    -- Signature over the event (added in TCK-00003)
+    signature BLOB
+);
+
+-- Index for efficient session-based queries
+CREATE INDEX IF NOT EXISTS idx_events_session
+ON events (session_id, seq_id);
+
+-- Index for time-based queries
+CREATE INDEX IF NOT EXISTS idx_events_timestamp
+ON events (timestamp_ns);
+
+-- Index for event type queries
+CREATE INDEX IF NOT EXISTS idx_events_type
+ON events (event_type, seq_id);
+
+-- Artifact references table: content-addressable storage references
+-- Links events to their associated artifacts stored in CAS
+CREATE TABLE IF NOT EXISTS artifact_refs (
+    -- Reference identifier
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+    -- Event this artifact is associated with
+    event_seq_id INTEGER NOT NULL,
+
+    -- Content hash (SHA-256) of the artifact
+    content_hash BLOB NOT NULL,
+
+    -- MIME type of the artifact
+    content_type TEXT NOT NULL,
+
+    -- Size in bytes
+    size_bytes INTEGER NOT NULL,
+
+    -- Storage location/path in CAS
+    storage_path TEXT NOT NULL,
+
+    -- Timestamp when reference was created
+    created_at_ns INTEGER NOT NULL,
+
+    FOREIGN KEY (event_seq_id) REFERENCES events(seq_id)
+);
+
+-- Index for looking up artifacts by content hash
+CREATE INDEX IF NOT EXISTS idx_artifact_refs_hash
+ON artifact_refs (content_hash);
+
+-- Index for looking up artifacts by event
+CREATE INDEX IF NOT EXISTS idx_artifact_refs_event
+ON artifact_refs (event_seq_id);

--- a/crates/apm2-core/src/ledger/storage.rs
+++ b/crates/apm2-core/src/ledger/storage.rs
@@ -1,0 +1,760 @@
+//! `SQLite`-backed ledger storage implementation.
+//!
+//! This module uses `SQLite` with WAL mode for the underlying storage.
+
+// SQLite returns i64 for row IDs and counts, but they're always non-negative.
+// Timestamps won't overflow u64 until the year 2554.
+// Mutex poisoning indicates a panic in another thread, which is unrecoverable.
+#![allow(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    clippy::missing_panics_doc
+)]
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
+use thiserror::Error;
+
+/// Schema SQL embedded at compile time.
+const SCHEMA_SQL: &str = include_str!("schema.sql");
+
+/// Errors that can occur during ledger operations.
+#[derive(Debug, Error)]
+pub enum LedgerError {
+    /// Database error from `SQLite`.
+    #[error("database error: {0}")]
+    Database(#[from] rusqlite::Error),
+
+    /// I/O error during database operations.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Attempted to modify an existing event (violates append-only).
+    #[error("cannot modify event {seq_id}: ledger is append-only")]
+    AppendOnlyViolation {
+        /// The sequence ID of the event that was attempted to be modified.
+        seq_id: u64,
+    },
+
+    /// Invalid sequence number requested.
+    #[error("invalid cursor position: {cursor}")]
+    InvalidCursor {
+        /// The invalid cursor value.
+        cursor: u64,
+    },
+
+    /// Event not found.
+    #[error("event not found: seq_id={seq_id}")]
+    EventNotFound {
+        /// The sequence ID that was not found.
+        seq_id: u64,
+    },
+}
+
+/// A single event record in the ledger.
+#[derive(Debug, Clone)]
+pub struct EventRecord {
+    /// Sequence ID (assigned by the ledger on append).
+    pub seq_id: Option<u64>,
+
+    /// Event type identifier.
+    pub event_type: String,
+
+    /// Session this event belongs to.
+    pub session_id: String,
+
+    /// Event payload (typically JSON).
+    pub payload: Vec<u8>,
+
+    /// Timestamp in nanoseconds since Unix epoch.
+    pub timestamp_ns: u64,
+
+    /// Hash of the previous event (for hash chaining).
+    pub prev_hash: Option<Vec<u8>>,
+
+    /// Hash of this event's content.
+    pub event_hash: Option<Vec<u8>>,
+
+    /// Signature over the event.
+    pub signature: Option<Vec<u8>>,
+}
+
+impl EventRecord {
+    /// Creates a new event record with the current timestamp.
+    ///
+    /// The `seq_id`, `prev_hash`, `event_hash`, and `signature` fields
+    /// are populated when the event is appended to the ledger or
+    /// when hash chaining is applied (TCK-00003).
+    #[must_use]
+    pub fn new(
+        event_type: impl Into<String>,
+        session_id: impl Into<String>,
+        payload: Vec<u8>,
+    ) -> Self {
+        let timestamp_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+
+        Self {
+            seq_id: None,
+            event_type: event_type.into(),
+            session_id: session_id.into(),
+            payload,
+            timestamp_ns,
+            prev_hash: None,
+            event_hash: None,
+            signature: None,
+        }
+    }
+
+    /// Creates a new event record with a specific timestamp.
+    #[must_use]
+    pub fn with_timestamp(
+        event_type: impl Into<String>,
+        session_id: impl Into<String>,
+        payload: Vec<u8>,
+        timestamp_ns: u64,
+    ) -> Self {
+        Self {
+            seq_id: None,
+            event_type: event_type.into(),
+            session_id: session_id.into(),
+            payload,
+            timestamp_ns,
+            prev_hash: None,
+            event_hash: None,
+            signature: None,
+        }
+    }
+}
+
+/// A reference to an artifact in content-addressable storage.
+#[derive(Debug, Clone)]
+pub struct ArtifactRef {
+    /// Reference ID (assigned by the ledger).
+    pub id: Option<u64>,
+
+    /// Event sequence ID this artifact is associated with.
+    pub event_seq_id: u64,
+
+    /// SHA-256 hash of the artifact content.
+    pub content_hash: Vec<u8>,
+
+    /// MIME type of the artifact.
+    pub content_type: String,
+
+    /// Size of the artifact in bytes.
+    pub size_bytes: u64,
+
+    /// Path to the artifact in CAS.
+    pub storage_path: String,
+
+    /// Timestamp when the reference was created.
+    pub created_at_ns: u64,
+}
+
+impl ArtifactRef {
+    /// Creates a new artifact reference.
+    #[must_use]
+    pub fn new(
+        event_seq_id: u64,
+        content_hash: Vec<u8>,
+        content_type: impl Into<String>,
+        size_bytes: u64,
+        storage_path: impl Into<String>,
+    ) -> Self {
+        let created_at_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+
+        Self {
+            id: None,
+            event_seq_id,
+            content_hash,
+            content_type: content_type.into(),
+            size_bytes,
+            storage_path: storage_path.into(),
+            created_at_ns,
+        }
+    }
+}
+
+/// Statistics about the ledger.
+#[derive(Debug, Clone, Default)]
+pub struct LedgerStats {
+    /// Total number of events.
+    pub event_count: u64,
+
+    /// Total number of artifact references.
+    pub artifact_count: u64,
+
+    /// Highest sequence ID (0 if empty).
+    pub max_seq_id: u64,
+
+    /// Database file size in bytes.
+    pub db_size_bytes: u64,
+}
+
+/// The append-only event ledger backed by `SQLite`.
+///
+/// The ledger uses `SQLite`'s WAL mode to allow concurrent reads while
+/// writes are in progress. Events are stored with monotonically increasing
+/// sequence numbers and can never be modified or deleted.
+pub struct Ledger {
+    conn: Arc<std::sync::Mutex<Connection>>,
+    #[allow(dead_code)]
+    path: Option<std::path::PathBuf>,
+}
+
+impl Ledger {
+    /// Opens or creates a ledger at the specified path.
+    ///
+    /// If the database doesn't exist, it will be created with the
+    /// appropriate schema. WAL mode is enabled for concurrent reads.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database cannot be opened or initialized.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, LedgerError> {
+        let path = path.as_ref();
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_CREATE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+
+        Self::initialize_connection(&conn)?;
+
+        Ok(Self {
+            conn: Arc::new(std::sync::Mutex::new(conn)),
+            path: Some(path.to_path_buf()),
+        })
+    }
+
+    /// Creates an in-memory ledger for testing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database cannot be initialized.
+    pub fn in_memory() -> Result<Self, LedgerError> {
+        let conn = Connection::open_in_memory()?;
+        Self::initialize_connection(&conn)?;
+
+        Ok(Self {
+            conn: Arc::new(std::sync::Mutex::new(conn)),
+            path: None,
+        })
+    }
+
+    /// Initialize the connection with schema and pragmas.
+    fn initialize_connection(conn: &Connection) -> Result<(), LedgerError> {
+        // Execute schema (includes PRAGMA statements)
+        conn.execute_batch(SCHEMA_SQL)?;
+        Ok(())
+    }
+
+    /// Appends an event to the ledger.
+    ///
+    /// Returns the assigned sequence ID for the event.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the event cannot be inserted.
+    pub fn append(&self, event: &EventRecord) -> Result<u64, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        conn.execute(
+            "INSERT INTO events (event_type, session_id, payload, timestamp_ns, prev_hash, event_hash, signature)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                event.event_type,
+                event.session_id,
+                event.payload,
+                event.timestamp_ns,
+                event.prev_hash,
+                event.event_hash,
+                event.signature,
+            ],
+        )?;
+
+        Ok(conn.last_insert_rowid() as u64)
+    }
+
+    /// Appends multiple events in a single transaction.
+    ///
+    /// Returns the sequence IDs assigned to each event in order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any event cannot be inserted. On error,
+    /// no events are inserted (atomic operation).
+    pub fn append_batch(&self, events: &[EventRecord]) -> Result<Vec<u64>, LedgerError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+
+        let mut seq_ids = Vec::with_capacity(events.len());
+
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO events (event_type, session_id, payload, timestamp_ns, prev_hash, event_hash, signature)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            )?;
+
+            for event in events {
+                stmt.execute(params![
+                    event.event_type,
+                    event.session_id,
+                    event.payload,
+                    event.timestamp_ns,
+                    event.prev_hash,
+                    event.event_hash,
+                    event.signature,
+                ])?;
+                seq_ids.push(tx.last_insert_rowid() as u64);
+            }
+        }
+
+        tx.commit()?;
+        Ok(seq_ids)
+    }
+
+    /// Reads events starting from a cursor position.
+    ///
+    /// Returns up to `limit` events with sequence IDs >= `cursor`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub fn read_from(&self, cursor: u64, limit: u64) -> Result<Vec<EventRecord>, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut stmt = conn.prepare(
+            "SELECT seq_id, event_type, session_id, payload, timestamp_ns, prev_hash, event_hash, signature
+             FROM events
+             WHERE seq_id >= ?1
+             ORDER BY seq_id ASC
+             LIMIT ?2",
+        )?;
+
+        let events = stmt
+            .query_map(params![cursor, limit], |row| {
+                Ok(EventRecord {
+                    seq_id: Some(row.get::<_, i64>(0)? as u64),
+                    event_type: row.get(1)?,
+                    session_id: row.get(2)?,
+                    payload: row.get(3)?,
+                    timestamp_ns: row.get::<_, i64>(4)? as u64,
+                    prev_hash: row.get(5)?,
+                    event_hash: row.get(6)?,
+                    signature: row.get(7)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(events)
+    }
+
+    /// Reads a single event by sequence ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EventNotFound` if no event exists with that sequence ID.
+    pub fn read_one(&self, seq_id: u64) -> Result<EventRecord, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut stmt = conn.prepare(
+            "SELECT seq_id, event_type, session_id, payload, timestamp_ns, prev_hash, event_hash, signature
+             FROM events
+             WHERE seq_id = ?1",
+        )?;
+
+        stmt.query_row(params![seq_id], |row| {
+            Ok(EventRecord {
+                seq_id: Some(row.get::<_, i64>(0)? as u64),
+                event_type: row.get(1)?,
+                session_id: row.get(2)?,
+                payload: row.get(3)?,
+                timestamp_ns: row.get::<_, i64>(4)? as u64,
+                prev_hash: row.get(5)?,
+                event_hash: row.get(6)?,
+                signature: row.get(7)?,
+            })
+        })
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => LedgerError::EventNotFound { seq_id },
+            other => LedgerError::Database(other),
+        })
+    }
+
+    /// Reads events for a specific session.
+    ///
+    /// Returns events in sequence order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub fn read_session(
+        &self,
+        session_id: &str,
+        limit: u64,
+    ) -> Result<Vec<EventRecord>, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut stmt = conn.prepare(
+            "SELECT seq_id, event_type, session_id, payload, timestamp_ns, prev_hash, event_hash, signature
+             FROM events
+             WHERE session_id = ?1
+             ORDER BY seq_id ASC
+             LIMIT ?2",
+        )?;
+
+        let events = stmt
+            .query_map(params![session_id, limit], |row| {
+                Ok(EventRecord {
+                    seq_id: Some(row.get::<_, i64>(0)? as u64),
+                    event_type: row.get(1)?,
+                    session_id: row.get(2)?,
+                    payload: row.get(3)?,
+                    timestamp_ns: row.get::<_, i64>(4)? as u64,
+                    prev_hash: row.get(5)?,
+                    event_hash: row.get(6)?,
+                    signature: row.get(7)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(events)
+    }
+
+    /// Reads events by type.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub fn read_by_type(
+        &self,
+        event_type: &str,
+        cursor: u64,
+        limit: u64,
+    ) -> Result<Vec<EventRecord>, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut stmt = conn.prepare(
+            "SELECT seq_id, event_type, session_id, payload, timestamp_ns, prev_hash, event_hash, signature
+             FROM events
+             WHERE event_type = ?1 AND seq_id >= ?2
+             ORDER BY seq_id ASC
+             LIMIT ?3",
+        )?;
+
+        let events = stmt
+            .query_map(params![event_type, cursor, limit], |row| {
+                Ok(EventRecord {
+                    seq_id: Some(row.get::<_, i64>(0)? as u64),
+                    event_type: row.get(1)?,
+                    session_id: row.get(2)?,
+                    payload: row.get(3)?,
+                    timestamp_ns: row.get::<_, i64>(4)? as u64,
+                    prev_hash: row.get(5)?,
+                    event_hash: row.get(6)?,
+                    signature: row.get(7)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(events)
+    }
+
+    /// Adds an artifact reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the reference cannot be inserted.
+    pub fn add_artifact_ref(&self, artifact: &ArtifactRef) -> Result<u64, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        conn.execute(
+            "INSERT INTO artifact_refs (event_seq_id, content_hash, content_type, size_bytes, storage_path, created_at_ns)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                artifact.event_seq_id,
+                artifact.content_hash,
+                artifact.content_type,
+                artifact.size_bytes,
+                artifact.storage_path,
+                artifact.created_at_ns,
+            ],
+        )?;
+
+        Ok(conn.last_insert_rowid() as u64)
+    }
+
+    /// Gets artifact references for an event.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub fn get_artifacts_for_event(
+        &self,
+        event_seq_id: u64,
+    ) -> Result<Vec<ArtifactRef>, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut stmt = conn.prepare(
+            "SELECT id, event_seq_id, content_hash, content_type, size_bytes, storage_path, created_at_ns
+             FROM artifact_refs
+             WHERE event_seq_id = ?1
+             ORDER BY id ASC",
+        )?;
+
+        let artifacts = stmt
+            .query_map(params![event_seq_id], |row| {
+                Ok(ArtifactRef {
+                    id: Some(row.get::<_, i64>(0)? as u64),
+                    event_seq_id: row.get::<_, i64>(1)? as u64,
+                    content_hash: row.get(2)?,
+                    content_type: row.get(3)?,
+                    size_bytes: row.get::<_, i64>(4)? as u64,
+                    storage_path: row.get(5)?,
+                    created_at_ns: row.get::<_, i64>(6)? as u64,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(artifacts)
+    }
+
+    /// Looks up an artifact by content hash.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub fn find_artifact_by_hash(
+        &self,
+        content_hash: &[u8],
+    ) -> Result<Option<ArtifactRef>, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut stmt = conn.prepare(
+            "SELECT id, event_seq_id, content_hash, content_type, size_bytes, storage_path, created_at_ns
+             FROM artifact_refs
+             WHERE content_hash = ?1
+             LIMIT 1",
+        )?;
+
+        let result = stmt
+            .query_row(params![content_hash], |row| {
+                Ok(ArtifactRef {
+                    id: Some(row.get::<_, i64>(0)? as u64),
+                    event_seq_id: row.get::<_, i64>(1)? as u64,
+                    content_hash: row.get(2)?,
+                    content_type: row.get(3)?,
+                    size_bytes: row.get::<_, i64>(4)? as u64,
+                    storage_path: row.get(5)?,
+                    created_at_ns: row.get::<_, i64>(6)? as u64,
+                })
+            })
+            .optional()?;
+
+        Ok(result)
+    }
+
+    /// Gets the current maximum sequence ID.
+    ///
+    /// Returns 0 if the ledger is empty.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub fn max_seq_id(&self) -> Result<u64, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        let max: Option<i64> =
+            conn.query_row("SELECT MAX(seq_id) FROM events", [], |row| row.get(0))?;
+
+        Ok(max.unwrap_or(0) as u64)
+    }
+
+    /// Gets statistics about the ledger.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if statistics cannot be gathered.
+    pub fn stats(&self) -> Result<LedgerStats, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        let event_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))?;
+
+        let artifact_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM artifact_refs", [], |row| row.get(0))?;
+
+        let max_seq_id: Option<i64> =
+            conn.query_row("SELECT MAX(seq_id) FROM events", [], |row| row.get(0))?;
+
+        // Get page count and page size to compute database size
+        let page_count: i64 = conn.query_row("PRAGMA page_count", [], |row| row.get(0))?;
+        let page_size: i64 = conn.query_row("PRAGMA page_size", [], |row| row.get(0))?;
+        let db_size_bytes = (page_count * page_size) as u64;
+
+        Ok(LedgerStats {
+            event_count: event_count as u64,
+            artifact_count: artifact_count as u64,
+            max_seq_id: max_seq_id.unwrap_or(0) as u64,
+            db_size_bytes,
+        })
+    }
+
+    /// Verifies that WAL mode is enabled.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the journal mode cannot be queried.
+    pub fn verify_wal_mode(&self) -> Result<bool, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        let mode: String = conn.query_row("PRAGMA journal_mode", [], |row| row.get(0))?;
+
+        Ok(mode.to_lowercase() == "wal")
+    }
+
+    /// Opens a read-only connection to the ledger for concurrent reads.
+    ///
+    /// This is useful for creating multiple readers that can read
+    /// concurrently while writes are in progress.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the path is not set (in-memory database)
+    /// or if the connection cannot be opened.
+    pub fn open_reader(&self) -> Result<LedgerReader, LedgerError> {
+        let path = self.path.as_ref().ok_or_else(|| {
+            LedgerError::Io(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "cannot create reader for in-memory database",
+            ))
+        })?;
+
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+
+        Ok(LedgerReader {
+            conn: Arc::new(std::sync::Mutex::new(conn)),
+        })
+    }
+}
+
+/// A read-only view of the ledger for concurrent reads.
+pub struct LedgerReader {
+    conn: Arc<std::sync::Mutex<Connection>>,
+}
+
+impl LedgerReader {
+    /// Reads events starting from a cursor position.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub fn read_from(&self, cursor: u64, limit: u64) -> Result<Vec<EventRecord>, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut stmt = conn.prepare(
+            "SELECT seq_id, event_type, session_id, payload, timestamp_ns, prev_hash, event_hash, signature
+             FROM events
+             WHERE seq_id >= ?1
+             ORDER BY seq_id ASC
+             LIMIT ?2",
+        )?;
+
+        let events = stmt
+            .query_map(params![cursor, limit], |row| {
+                Ok(EventRecord {
+                    seq_id: Some(row.get::<_, i64>(0)? as u64),
+                    event_type: row.get(1)?,
+                    session_id: row.get(2)?,
+                    payload: row.get(3)?,
+                    timestamp_ns: row.get::<_, i64>(4)? as u64,
+                    prev_hash: row.get(5)?,
+                    event_hash: row.get(6)?,
+                    signature: row.get(7)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(events)
+    }
+
+    /// Reads a single event by sequence ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EventNotFound` if no event exists with that sequence ID.
+    pub fn read_one(&self, seq_id: u64) -> Result<EventRecord, LedgerError> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut stmt = conn.prepare(
+            "SELECT seq_id, event_type, session_id, payload, timestamp_ns, prev_hash, event_hash, signature
+             FROM events
+             WHERE seq_id = ?1",
+        )?;
+
+        stmt.query_row(params![seq_id], |row| {
+            Ok(EventRecord {
+                seq_id: Some(row.get::<_, i64>(0)? as u64),
+                event_type: row.get(1)?,
+                session_id: row.get(2)?,
+                payload: row.get(3)?,
+                timestamp_ns: row.get::<_, i64>(4)? as u64,
+                prev_hash: row.get(5)?,
+                event_hash: row.get(6)?,
+                signature: row.get(7)?,
+            })
+        })
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => LedgerError::EventNotFound { seq_id },
+            other => LedgerError::Database(other),
+        })
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn test_event_record_new() {
+        let event = EventRecord::new("test.event", "session-1", b"payload".to_vec());
+
+        assert!(event.seq_id.is_none());
+        assert_eq!(event.event_type, "test.event");
+        assert_eq!(event.session_id, "session-1");
+        assert_eq!(event.payload, b"payload");
+        assert!(event.timestamp_ns > 0);
+    }
+
+    #[test]
+    fn test_artifact_ref_new() {
+        let artifact = ArtifactRef::new(
+            1,
+            vec![0u8; 32],
+            "application/json",
+            1024,
+            "/path/to/artifact",
+        );
+
+        assert!(artifact.id.is_none());
+        assert_eq!(artifact.event_seq_id, 1);
+        assert_eq!(artifact.content_hash.len(), 32);
+        assert_eq!(artifact.content_type, "application/json");
+        assert_eq!(artifact.size_bytes, 1024);
+        assert!(artifact.created_at_ns > 0);
+    }
+}

--- a/crates/apm2-core/src/ledger/tests.rs
+++ b/crates/apm2-core/src/ledger/tests.rs
@@ -1,0 +1,493 @@
+//! Tests for the ledger storage layer.
+
+use std::thread;
+
+use tempfile::TempDir;
+
+use super::*;
+
+/// Helper to create a temporary ledger for testing.
+fn temp_ledger() -> (Ledger, TempDir) {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let path = dir.path().join("test_ledger.db");
+    let ledger = Ledger::open(&path).expect("failed to open ledger");
+    (ledger, dir)
+}
+
+#[test]
+fn test_create_ledger() {
+    let (ledger, _dir) = temp_ledger();
+
+    let stats = ledger.stats().expect("failed to get stats");
+    assert_eq!(stats.event_count, 0);
+    assert_eq!(stats.artifact_count, 0);
+    assert_eq!(stats.max_seq_id, 0);
+}
+
+#[test]
+fn test_in_memory_ledger() {
+    let ledger = Ledger::in_memory().expect("failed to create in-memory ledger");
+
+    let stats = ledger.stats().expect("failed to get stats");
+    assert_eq!(stats.event_count, 0);
+}
+
+#[test]
+fn test_append_single_event() {
+    let (ledger, _dir) = temp_ledger();
+
+    let event = EventRecord::new("test.event", "session-1", b"test payload".to_vec());
+    let seq_id = ledger.append(&event).expect("failed to append event");
+
+    assert_eq!(seq_id, 1);
+
+    let stats = ledger.stats().expect("failed to get stats");
+    assert_eq!(stats.event_count, 1);
+    assert_eq!(stats.max_seq_id, 1);
+}
+
+#[test]
+fn test_append_preserves_order() {
+    let (ledger, _dir) = temp_ledger();
+
+    let seq1 = ledger
+        .append(&EventRecord::new("event.1", "session-1", b"first".to_vec()))
+        .expect("failed to append");
+    let seq2 = ledger
+        .append(&EventRecord::new(
+            "event.2",
+            "session-1",
+            b"second".to_vec(),
+        ))
+        .expect("failed to append");
+    let seq3 = ledger
+        .append(&EventRecord::new("event.3", "session-1", b"third".to_vec()))
+        .expect("failed to append");
+
+    assert_eq!(seq1, 1);
+    assert_eq!(seq2, 2);
+    assert_eq!(seq3, 3);
+
+    // Verify order via read
+    let events = ledger.read_from(0, 10).expect("failed to read");
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].seq_id, Some(1));
+    assert_eq!(events[1].seq_id, Some(2));
+    assert_eq!(events[2].seq_id, Some(3));
+}
+
+#[test]
+fn test_append_batch() {
+    let (ledger, _dir) = temp_ledger();
+
+    let events = vec![
+        EventRecord::new("batch.1", "session-1", b"first".to_vec()),
+        EventRecord::new("batch.2", "session-1", b"second".to_vec()),
+        EventRecord::new("batch.3", "session-1", b"third".to_vec()),
+    ];
+
+    let seq_ids = ledger
+        .append_batch(&events)
+        .expect("failed to append batch");
+
+    assert_eq!(seq_ids, vec![1, 2, 3]);
+
+    let stats = ledger.stats().expect("failed to get stats");
+    assert_eq!(stats.event_count, 3);
+}
+
+#[test]
+fn test_read_from_cursor() {
+    let (ledger, _dir) = temp_ledger();
+
+    // Append 5 events
+    for i in 1..=5 {
+        ledger
+            .append(&EventRecord::new(
+                format!("event.{i}"),
+                "session-1",
+                format!("payload-{i}").into_bytes(),
+            ))
+            .expect("failed to append");
+    }
+
+    // Read from cursor 3
+    let events = ledger.read_from(3, 10).expect("failed to read");
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].seq_id, Some(3));
+    assert_eq!(events[1].seq_id, Some(4));
+    assert_eq!(events[2].seq_id, Some(5));
+}
+
+#[test]
+fn test_read_with_limit() {
+    let (ledger, _dir) = temp_ledger();
+
+    // Append 10 events
+    for i in 1..=10 {
+        ledger
+            .append(&EventRecord::new("event", "session-1", vec![i]))
+            .expect("failed to append");
+    }
+
+    // Read with limit 3
+    let events = ledger.read_from(1, 3).expect("failed to read");
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].seq_id, Some(1));
+    assert_eq!(events[2].seq_id, Some(3));
+}
+
+#[test]
+fn test_read_one() {
+    let (ledger, _dir) = temp_ledger();
+
+    let event = EventRecord::new("test.read", "session-1", b"payload data".to_vec());
+    let seq_id = ledger.append(&event).expect("failed to append");
+
+    let read_event = ledger.read_one(seq_id).expect("failed to read");
+
+    assert_eq!(read_event.seq_id, Some(seq_id));
+    assert_eq!(read_event.event_type, "test.read");
+    assert_eq!(read_event.session_id, "session-1");
+    assert_eq!(read_event.payload, b"payload data");
+}
+
+#[test]
+fn test_read_one_not_found() {
+    let (ledger, _dir) = temp_ledger();
+
+    let result = ledger.read_one(999);
+
+    assert!(matches!(
+        result,
+        Err(LedgerError::EventNotFound { seq_id: 999 })
+    ));
+}
+
+#[test]
+fn test_read_session() {
+    let (ledger, _dir) = temp_ledger();
+
+    // Append events to different sessions
+    ledger
+        .append(&EventRecord::new("event.1", "session-a", b"a1".to_vec()))
+        .unwrap();
+    ledger
+        .append(&EventRecord::new("event.2", "session-b", b"b1".to_vec()))
+        .unwrap();
+    ledger
+        .append(&EventRecord::new("event.3", "session-a", b"a2".to_vec()))
+        .unwrap();
+    ledger
+        .append(&EventRecord::new("event.4", "session-b", b"b2".to_vec()))
+        .unwrap();
+    ledger
+        .append(&EventRecord::new("event.5", "session-a", b"a3".to_vec()))
+        .unwrap();
+
+    // Read session-a
+    let session_a_events = ledger
+        .read_session("session-a", 100)
+        .expect("failed to read");
+    assert_eq!(session_a_events.len(), 3);
+    assert_eq!(session_a_events[0].payload, b"a1");
+    assert_eq!(session_a_events[1].payload, b"a2");
+    assert_eq!(session_a_events[2].payload, b"a3");
+
+    // Read session-b
+    let session_b_events = ledger
+        .read_session("session-b", 100)
+        .expect("failed to read");
+    assert_eq!(session_b_events.len(), 2);
+}
+
+#[test]
+fn test_read_by_type() {
+    let (ledger, _dir) = temp_ledger();
+
+    ledger
+        .append(&EventRecord::new("session.start", "s1", b"".to_vec()))
+        .unwrap();
+    ledger
+        .append(&EventRecord::new("tool.request", "s1", b"".to_vec()))
+        .unwrap();
+    ledger
+        .append(&EventRecord::new("tool.response", "s1", b"".to_vec()))
+        .unwrap();
+    ledger
+        .append(&EventRecord::new("tool.request", "s1", b"".to_vec()))
+        .unwrap();
+    ledger
+        .append(&EventRecord::new("session.end", "s1", b"".to_vec()))
+        .unwrap();
+
+    let tool_requests = ledger
+        .read_by_type("tool.request", 0, 100)
+        .expect("failed to read");
+    assert_eq!(tool_requests.len(), 2);
+    assert_eq!(tool_requests[0].seq_id, Some(2));
+    assert_eq!(tool_requests[1].seq_id, Some(4));
+}
+
+#[test]
+fn test_artifact_ref_crud() {
+    let (ledger, _dir) = temp_ledger();
+
+    // First create an event
+    let seq_id = ledger
+        .append(&EventRecord::new(
+            "event.with.artifact",
+            "session-1",
+            b"".to_vec(),
+        ))
+        .expect("failed to append");
+
+    // Add artifact reference
+    let artifact = ArtifactRef::new(
+        seq_id,
+        vec![0xab; 32], // mock hash
+        "application/json",
+        1024,
+        "/cas/ab/cd/abcd1234",
+    );
+    let artifact_id = ledger
+        .add_artifact_ref(&artifact)
+        .expect("failed to add artifact");
+    assert_eq!(artifact_id, 1);
+
+    // Retrieve artifacts for event
+    let artifacts = ledger
+        .get_artifacts_for_event(seq_id)
+        .expect("failed to get artifacts");
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].content_type, "application/json");
+    assert_eq!(artifacts[0].size_bytes, 1024);
+}
+
+#[test]
+fn test_find_artifact_by_hash() {
+    let (ledger, _dir) = temp_ledger();
+
+    let seq_id = ledger
+        .append(&EventRecord::new("event", "session-1", b"".to_vec()))
+        .unwrap();
+
+    let hash = vec![0xde, 0xad, 0xbe, 0xef];
+    let artifact = ArtifactRef::new(
+        seq_id,
+        hash.clone(),
+        "text/plain",
+        256,
+        "/cas/de/ad/deadbeef",
+    );
+    ledger.add_artifact_ref(&artifact).unwrap();
+
+    // Find by hash
+    let found = ledger
+        .find_artifact_by_hash(&hash)
+        .expect("failed to find")
+        .expect("artifact not found");
+    assert_eq!(found.content_type, "text/plain");
+    assert_eq!(found.size_bytes, 256);
+
+    // Not found
+    let not_found = ledger
+        .find_artifact_by_hash(&[0x00; 32])
+        .expect("failed to query");
+    assert!(not_found.is_none());
+}
+
+#[test]
+fn test_multiple_artifacts_per_event() {
+    let (ledger, _dir) = temp_ledger();
+
+    let seq_id = ledger
+        .append(&EventRecord::new("event", "session-1", b"".to_vec()))
+        .unwrap();
+
+    // Add multiple artifacts
+    for i in 0..3 {
+        let artifact = ArtifactRef::new(
+            seq_id,
+            vec![i; 32],
+            format!("type/{i}"),
+            (i as u64 + 1) * 100,
+            format!("/cas/{i}"),
+        );
+        ledger.add_artifact_ref(&artifact).unwrap();
+    }
+
+    let artifacts = ledger.get_artifacts_for_event(seq_id).unwrap();
+    assert_eq!(artifacts.len(), 3);
+}
+
+#[test]
+fn test_wal_mode_enabled() {
+    let (ledger, _dir) = temp_ledger();
+
+    let is_wal = ledger.verify_wal_mode().expect("failed to verify WAL mode");
+    assert!(is_wal, "WAL mode should be enabled");
+}
+
+#[test]
+fn test_concurrent_read_with_wal() {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let path = dir.path().join("concurrent_test.db");
+
+    let ledger = Ledger::open(&path).expect("failed to open ledger");
+
+    // Append some initial events
+    for i in 1..=10 {
+        ledger
+            .append(&EventRecord::new("init.event", "session-1", vec![i]))
+            .unwrap();
+    }
+
+    // Create a reader
+    let reader = ledger.open_reader().expect("failed to open reader");
+
+    // Start a thread that writes more events
+    let write_ledger = Ledger::open(&path).expect("failed to open write ledger");
+    let write_handle = thread::spawn(move || {
+        for i in 11..=20 {
+            write_ledger
+                .append(&EventRecord::new("write.event", "session-2", vec![i]))
+                .unwrap();
+            thread::sleep(std::time::Duration::from_millis(5));
+        }
+    });
+
+    // Concurrent read while writing
+    let mut read_count = 0;
+    for _ in 0..5 {
+        let events = reader.read_from(1, 100).expect("failed to read");
+        read_count = events.len();
+        thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    write_handle.join().expect("write thread panicked");
+
+    // Final read should see all events
+    let final_events = reader.read_from(1, 100).expect("failed to read");
+    assert_eq!(final_events.len(), 20);
+    assert!(read_count > 0, "concurrent reads should succeed");
+}
+
+#[test]
+fn test_max_seq_id() {
+    let (ledger, _dir) = temp_ledger();
+
+    assert_eq!(ledger.max_seq_id().unwrap(), 0);
+
+    ledger.append(&EventRecord::new("e", "s", vec![])).unwrap();
+    assert_eq!(ledger.max_seq_id().unwrap(), 1);
+
+    ledger.append(&EventRecord::new("e", "s", vec![])).unwrap();
+    ledger.append(&EventRecord::new("e", "s", vec![])).unwrap();
+    assert_eq!(ledger.max_seq_id().unwrap(), 3);
+}
+
+#[test]
+fn test_stats() {
+    let (ledger, _dir) = temp_ledger();
+
+    // Append events and artifacts
+    for i in 1..=5 {
+        let seq_id = ledger
+            .append(&EventRecord::new("event", "session", vec![i]))
+            .unwrap();
+
+        if i % 2 == 0 {
+            ledger
+                .add_artifact_ref(&ArtifactRef::new(seq_id, vec![i; 32], "type", 100, "/path"))
+                .unwrap();
+        }
+    }
+
+    let stats = ledger.stats().expect("failed to get stats");
+    assert_eq!(stats.event_count, 5);
+    assert_eq!(stats.artifact_count, 2);
+    assert_eq!(stats.max_seq_id, 5);
+    assert!(stats.db_size_bytes > 0);
+}
+
+#[test]
+fn test_event_timestamp_preserved() {
+    let ledger = Ledger::in_memory().unwrap();
+
+    let timestamp_ns = 1_700_000_000_000_000_000u64;
+    let event = EventRecord::with_timestamp("test", "session", b"data".to_vec(), timestamp_ns);
+
+    let seq_id = ledger.append(&event).unwrap();
+    let read_event = ledger.read_one(seq_id).unwrap();
+
+    assert_eq!(read_event.timestamp_ns, timestamp_ns);
+}
+
+#[test]
+fn test_payload_preserved() {
+    let ledger = Ledger::in_memory().unwrap();
+
+    // Test with various payload types
+    let payloads = vec![
+        vec![],                       // empty
+        b"simple ascii".to_vec(),     // ascii
+        vec![0, 1, 2, 255, 254, 253], // binary
+        b"{\"json\": true}".to_vec(), // json
+        vec![0u8; 10000],             // large
+    ];
+
+    for payload in payloads {
+        let event = EventRecord::new("test", "session", payload.clone());
+        let seq_id = ledger.append(&event).unwrap();
+        let read_event = ledger.read_one(seq_id).unwrap();
+        assert_eq!(read_event.payload, payload);
+    }
+}
+
+#[test]
+fn test_empty_ledger_reads() {
+    let ledger = Ledger::in_memory().unwrap();
+
+    let events = ledger.read_from(0, 100).unwrap();
+    assert!(events.is_empty());
+
+    let events = ledger.read_session("nonexistent", 100).unwrap();
+    assert!(events.is_empty());
+
+    let events = ledger.read_by_type("nonexistent", 0, 100).unwrap();
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_reader_isolation() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("reader_isolation.db");
+
+    let ledger = Ledger::open(&path).unwrap();
+
+    // Add initial events
+    for i in 1..=5 {
+        ledger
+            .append(&EventRecord::new("event", "session", vec![i]))
+            .unwrap();
+    }
+
+    // Create reader
+    let reader = ledger.open_reader().unwrap();
+
+    // Reader should see 5 events
+    let events = reader.read_from(1, 100).unwrap();
+    assert_eq!(events.len(), 5);
+
+    // Add more events via main connection
+    for i in 6..=10 {
+        ledger
+            .append(&EventRecord::new("event", "session", vec![i]))
+            .unwrap();
+    }
+
+    // Reader should now see all 10 (WAL provides snapshot isolation per query)
+    let events = reader.read_from(1, 100).unwrap();
+    assert_eq!(events.len(), 10);
+}

--- a/crates/apm2-core/src/lib.rs
+++ b/crates/apm2-core/src/lib.rs
@@ -37,6 +37,7 @@ pub mod config;
 pub mod credentials;
 pub mod health;
 pub mod ipc;
+pub mod ledger;
 pub mod log;
 pub mod process;
 pub mod restart;


### PR DESCRIPTION
## Summary

- Implement append-only event ledger backed by SQLite with WAL mode for concurrent reads
- Create events table with monotonic sequence IDs for event ordering
- Implement cursor-based read operations for efficient pagination
- Create artifact_refs table for content-addressable storage references
- Add 24 comprehensive unit tests covering all CRUD operations

## Ticket

Implements TCK-00001: Implement ledger storage layer with SQLite WAL

## Files Changed

- `crates/apm2-core/src/ledger/mod.rs` - Module exports and documentation
- `crates/apm2-core/src/ledger/storage.rs` - SQLite implementation
- `crates/apm2-core/src/ledger/schema.sql` - DDL for events and artifact_refs tables
- `crates/apm2-core/src/ledger/tests.rs` - Unit tests

## Test plan

- [x] `cargo build --package apm2-core` - Compiles without errors
- [x] `cargo test --package apm2-core ledger` - All 24 tests pass
- [x] `cargo clippy --package apm2-core -- -D warnings` - No warnings
- [x] WAL mode verified with concurrent read test

## Evidence

EVID-0004

🤖 Generated with [Claude Code](https://claude.com/claude-code)