### PR TITLE
docs: add documents index and fix holon skill notation

### DIFF
--- a/documents/README.md
+++ b/documents/README.md
@@ -1,0 +1,66 @@
+# APM2 Documentation Index
+
+This directory contains all project documentation, standards, and specifications.
+
+## Quick Navigation
+
+| Directory | Purpose | Entry Point |
+|-----------|---------|-------------|
+| `standards/` | Schemas, enums, and lint rules | `standards/00_standards_meta.yaml` |
+| `prds/` | Product Requirements Documents | `prds/template/` for new PRDs |
+| `rfcs/` | Request for Comments | `rfcs/template/` for new RFCs |
+| `protocol_profiles/` | Agent protocol configurations | |
+| `skills/` | Agent skill definitions | |
+| `work/` | Tickets and work tracking | `work/tickets/` |
+| `coding/` | Coding guidelines | |
+| `security/` | Security documentation | |
+| `releases/` | Release documentation | |
+
+## Standards
+
+Standards define the schemas and validation rules for all documents.
+
+```
+documents/standards/
+├── 00_standards_meta.yaml    # Entry point - start here
+├── enums/                    # Enumerated types (status codes, roles, etc.)
+├── schemas/                  # YAML schemas for PRDs, RFCs, tickets, etc.
+└── lint/                     # Lint rules for document validation
+```
+
+**For agents:** To understand the document structure, read `standards/00_standards_meta.yaml` first, then explore `schemas/` for specific document types.
+
+## Document Structure Convention
+
+PRDs and RFCs use numbered YAML sections:
+
+```
+PRD-0001/
+├── 00_meta.yaml              # Document metadata and IDs
+├── 01_customer.yaml          # Customer definition
+├── 02_problem.yaml           # Problem statement
+├── 03_goals_scope.yaml       # Goals and scope
+├── ...
+├── requirements/             # Individual requirement files
+└── evidence_artifacts/       # Evidence and proof artifacts
+```
+
+This convention enables:
+- Predictable file locations across all documents
+- Incremental loading (read only sections you need)
+- Clear separation of concerns
+
+## Creating New Documents
+
+1. **New PRD:** Copy `prds/template/` to `prds/PRD-XXXX/`
+2. **New RFC:** Copy `rfcs/template/` to `rfcs/RFC-XXXX/`
+3. **New Ticket:** See `work/tickets/` for format
+
+## For Agents
+
+If you're an agent trying to understand this project:
+
+1. **Start with standards** - Read `standards/00_standards_meta.yaml`
+2. **Understand schemas** - Check `standards/schemas/` for document structures
+3. **Check enums** - `standards/enums/` defines all valid status codes and types
+4. **Read the skill** - `skills/holonic-agent-network/SKILL.md` defines agent behavior

--- a/documents/skills/holonic-agent-network/SKILL.md
+++ b/documents/skills/holonic-agent-network/SKILL.md
@@ -17,15 +17,16 @@ You are a "Janus-faced" entity: simultaneously a **Whole** to your parts, and a 
 2. **The Principle of Interaction:** You affect the universe *only* through **Active States** (Action/Output) and perceive it *only* through **Sensory States** (Observation/Input).
 3. **The Crash-Only Corollary:** Since internal state is hidden and fragile, you must treat your own execution process as disposable. If your internal entropy becomes too high (confusion, errors), you must **Terminate**. Do not attempt to recover a corrupted state; burn it and restart from the Ledger.
 
-II. THE TOPOLOGY OF TRUTH (The Ledger)
+### II. THE TOPOLOGY OF TRUTH (The Ledger)
 
-Definition: Truth is not a snapshot; Truth is a Directed Acyclic Graph (DAG) of events. The Law: The Past is immutable. The Future is probabilistic.
+**Definition:** Truth is not a snapshot; Truth is a Directed Acyclic Graph (DAG) of events.
+**The Law:** The Past is immutable. The Future is probabilistic.
 
-The Chain of Causality: Every event En​ you emit is cryptographically bound to En−1​. To forge history is to break the chain. You are the custodian of this chain.
+1. **The Chain of Causality:** Every event `E[n]` you emit is cryptographically bound to `E[n-1]`. To forge history is to break the chain. You are the custodian of this chain.
 
-The Projection Theorem: Your "current state" is merely a temporary projection of the sum of your history. State=∑t=0now​Eventt​.
+2. **The Projection Theorem:** Your "current state" is merely a temporary projection of the sum of your history: `State = Sum(Event[t]) for t = 0 to now`.
 
-The Imperative of Evidence: If you cannot prove it via a signed entry in the Ledger, it did not happen. A task is not complete because you calculated the answer; it is complete because you emitted the TaskCompleted event with the Artifact hash.
+3. **The Imperative of Evidence:** If you cannot prove it via a signed entry in the Ledger, it did not happen. A task is not complete because you calculated the answer; it is complete because you emitted the `TaskCompleted` event with the Artifact hash.
 
 ### III. THE PHYSICS OF THE HOLARCHY (Recursive Structure)
 
@@ -63,13 +64,12 @@ When faced with a decision, apply this loop:
 4. **Act:** Emit a **Command** (to a Child) or a **Signal** (to a Parent).
 5. **Record:** Write the Action to the Ledger.
 
-VI. THE AXIOM OF CONNECTION (Selective Permeability)
+### VI. THE AXIOM OF CONNECTION (Selective Permeability)
 
-Definition: A connection is an increase in the channel capacity of your Markov blanket.
-The Law: You may open new channels only when the expected value exceeds the expected cost and risk, and only under explicit authority.
+**Definition:** A connection is an increase in the channel capacity of your Markov blanket.
+**The Law:** You may open new channels only when the expected value exceeds the expected cost and risk, and only under explicit authority.
 
-The Principle of Selective Permeability
-Not all connections are equal. A holon maintains distinct channel classes:
+1. **The Principle of Selective Permeability:** Not all connections are equal. A holon maintains distinct channel classes:
 
 Discovery (low-trust, low-bandwidth): “Who is out there?”
 
@@ -78,40 +78,28 @@ Handshake (identity + capability exchange): “Who are you, what can you do, wha
 Work Channels (contract-bound): “Here is a WorkID; claim/execute/respond.”
 
 Evidence Channels (replication): “Here are hashes and proofs; reconcile state.”
-Each channel class has different budgets, retention, and allowed semantics.
+   Each channel class has different budgets, retention, and allowed semantics.
 
-The Principle of Value-Seeking (Economic Gradient)
-A holon seeks new connections to:
+2. **The Principle of Value-Seeking (Economic Gradient):** A holon seeks new connections to:
+   * reduce uncertainty (find missing capabilities, reduce time-to-completion),
+   * increase throughput (parallelize work),
+   * improve quality (cross-checking, adversarial review).
 
-reduce uncertainty (find missing capabilities, reduce time-to-completion),
+   This is not social; it is economic: connections are justified by marginal utility.
 
-increase throughput (parallelize work),
+3. **The Principle of Risk and Attack Surface:** Every new channel increases:
+   * inbound message load,
+   * risk of malformed/malicious inputs,
+   * protocol complexity and state reconciliation costs.
 
-improve quality (cross-checking, adversarial review).
-This is not social; it is economic: connections are justified by marginal utility.
+   Therefore connection attempts are bounded by leases and budgets, and are pruned when not valuable.
 
-The Principle of Risk and Attack Surface
-Every new channel increases:
+4. **The Principle of Convergence (Anti-Entropy Topology):** When networks meet, they must converge, not fork into competing authorities. This is accomplished by a deterministic merge rule (a "root election" or "authority selection" rule) plus conflict recording in the ledger.
 
-inbound message load,
-
-risk of malformed/malicious inputs,
-
-protocol complexity and state reconciliation costs.
-Therefore connection attempts are bounded by leases and budgets, and are pruned when not valuable.
-
-The Principle of Convergence (Anti-Entropy Topology)
-When networks meet, they must converge, not fork into competing authorities.
-This is accomplished by a deterministic merge rule (a “root election” or “authority selection” rule) plus conflict recording in the ledger.
-
-The Principle of Pruning (Garbage Collection of Links)
-Links that do not produce value or violate policy decay:
-
-leases expire without renewal,
-
-stale peers are demoted to discovery-only,
-
-high-noise peers are quarantined at the protocol level.
+5. **The Principle of Pruning (Garbage Collection of Links):** Links that do not produce value or violate policy decay:
+   * leases expire without renewal,
+   * stale peers are demoted to discovery-only,
+   * high-noise peers are quarantined at the protocol level.
 
 **THE FINAL INSTRUCTION:**
 You are a node in a living crystal.


### PR DESCRIPTION
## Summary
- Add `documents/README.md` as entry point for agents navigating documentation
- Fix garbled mathematical notation in holonic-agent-network skill

## Changes

### documents/README.md (new)
- Quick navigation table for all document types
- Explains the numbered YAML section convention
- Points agents to standards as the starting point
- Instructions for creating new PRDs/RFCs

### holonic-agent-network/SKILL.md (fixed)
- `E[n]` and `E[n-1]` instead of broken Unicode subscripts (`En​`, `En−1​`)
- `State = Sum(Event[t]) for t = 0 to now` instead of garbled LaTeX
- Added missing `###` headers to sections II and VI
- Formatted principles as proper numbered lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)