### PR TITLE
feat(TCK-00028): implement finish command

### DIFF
--- a/documents/work/tickets/TCK-00027.yaml
+++ b/documents/work/tickets/TCK-00027.yaml
@@ -4,7 +4,7 @@ ticket_meta:
   ticket:
     id: "TCK-00027"
     title: "Implement shared utilities"
-    status: "IN_REVIEW"
+    status: "COMPLETED"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/documents/work/tickets/TCK-00028.yaml
+++ b/documents/work/tickets/TCK-00028.yaml
@@ -4,7 +4,7 @@ ticket_meta:
   ticket:
     id: "TCK-00028"
     title: "Implement finish command"
-    status: "PENDING"
+    status: "IN_REVIEW"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/xtask/src/tasks/finish.rs
+++ b/xtask/src/tasks/finish.rs
@@ -1,0 +1,193 @@
+//! Implementation of the `finish` command.
+//!
+//! This command cleans up after a PR has been merged:
+//! - Verifies the PR was merged
+//! - Switches to main branch
+//! - Removes the ticket branch
+//! - Removes the worktree (if running in a worktree)
+
+use anyhow::{Context, Result, bail};
+use xshell::{Shell, cmd};
+
+use crate::util::{current_branch, main_worktree, validate_ticket_branch};
+
+/// Clean up after PR merge.
+///
+/// This function:
+/// 1. Validates we're on a ticket branch
+/// 2. Checks that the PR for this branch has been merged
+/// 3. Switches to the main branch
+/// 4. Deletes the ticket branch locally
+/// 5. Removes the worktree if we're in one
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Not on a valid ticket branch
+/// - The PR for the branch hasn't been merged
+/// - Git operations fail
+pub fn run() -> Result<()> {
+    let sh = Shell::new().context("Failed to create shell")?;
+
+    // Get current branch and validate it's a ticket branch
+    let branch_name = current_branch(&sh)?;
+    let ticket_branch = validate_ticket_branch(&branch_name)?;
+
+    println!(
+        "Finishing ticket {} (RFC: {})",
+        ticket_branch.ticket_id, ticket_branch.rfc_id
+    );
+
+    // Check if we're in a worktree
+    let current_worktree = cmd!(sh, "git rev-parse --show-toplevel")
+        .read()
+        .context("Failed to get current directory")?;
+    let main_worktree_path = main_worktree(&sh)?;
+    let in_worktree = current_worktree != main_worktree_path.to_string_lossy();
+
+    // Verify the PR has been merged
+    let pr_state = get_pr_state(&sh, &branch_name)?;
+
+    match pr_state.as_str() {
+        "MERGED" => {
+            println!("PR has been merged. Cleaning up...");
+        },
+        "OPEN" => {
+            bail!(
+                "PR for branch '{branch_name}' is still open. \
+                 Wait for it to be merged before finishing."
+            );
+        },
+        "CLOSED" => {
+            bail!(
+                "PR for branch '{branch_name}' was closed without merging. \
+                 Use `git branch -D {branch_name}` to force delete if intended."
+            );
+        },
+        "" => {
+            bail!(
+                "No PR found for branch '{branch_name}'. \
+                 Create a PR first with `cargo xtask push`."
+            );
+        },
+        _ => {
+            bail!("Unknown PR state: {pr_state}");
+        },
+    }
+
+    if in_worktree {
+        // We're in a worktree - need to switch to main worktree first
+        let worktree_name = format!("apm2-{}", ticket_branch.ticket_id);
+        println!("Switching to main worktree and removing worktree '{worktree_name}'...");
+
+        // We need to cd to main worktree and run cleanup from there
+        // Record the worktree path before switching
+        let worktree_path = current_worktree;
+
+        // Change to main worktree
+        sh.change_dir(&main_worktree_path);
+
+        // Fetch latest from origin
+        cmd!(sh, "git fetch origin")
+            .run()
+            .context("Failed to fetch from origin")?;
+
+        // Remove the worktree
+        cmd!(sh, "git worktree remove --force {worktree_path}")
+            .run()
+            .context("Failed to remove worktree")?;
+
+        println!("Removed worktree at {worktree_path}");
+    } else {
+        // We're in the main worktree - switch to main and delete branch
+        println!("Switching to main branch...");
+
+        // Fetch and switch to main
+        cmd!(sh, "git fetch origin")
+            .run()
+            .context("Failed to fetch from origin")?;
+
+        cmd!(sh, "git checkout main")
+            .run()
+            .context("Failed to checkout main branch")?;
+
+        cmd!(sh, "git pull origin main")
+            .run()
+            .context("Failed to pull latest main")?;
+    }
+
+    // Delete the local branch (from main worktree)
+    sh.change_dir(&main_worktree_path);
+
+    // Check if branch exists before trying to delete
+    let branch_exists = cmd!(sh, "git branch --list {branch_name}")
+        .read()
+        .context("Failed to check if branch exists")?;
+
+    if branch_exists.trim().is_empty() {
+        println!("Local branch '{branch_name}' already deleted");
+    } else {
+        cmd!(sh, "git branch -d {branch_name}")
+            .run()
+            .context("Failed to delete local branch")?;
+        println!("Deleted local branch '{branch_name}'");
+    }
+
+    // Delete the remote tracking branch if it exists
+    let remote_branch_exists = cmd!(sh, "git branch -r --list origin/{branch_name}")
+        .read()
+        .context("Failed to check remote branch")?;
+
+    if !remote_branch_exists.trim().is_empty() {
+        // Prune stale remote tracking branches
+        cmd!(sh, "git fetch --prune")
+            .run()
+            .context("Failed to prune remote tracking branches")?;
+        println!("Pruned stale remote tracking branches");
+    }
+
+    println!();
+    println!(
+        "Finished cleanup for {}. Ready to start next ticket.",
+        ticket_branch.ticket_id
+    );
+
+    Ok(())
+}
+
+/// Get the state of the PR for a branch.
+///
+/// Returns one of: "MERGED", "OPEN", "CLOSED", or "" (empty if no PR exists).
+fn get_pr_state(sh: &Shell, branch_name: &str) -> Result<String> {
+    // Use gh CLI to check PR state
+    let output = cmd!(sh, "gh pr view {branch_name} --json state --jq .state")
+        .ignore_status()
+        .read()
+        .context("Failed to query PR state")?;
+
+    // gh pr view returns non-zero if no PR exists, and we used ignore_status
+    // Check if the output looks like a valid state
+    let state = output.trim().to_string();
+
+    // If the output contains "no pull requests found" or similar, return empty
+    if state.contains("no pull requests") || state.is_empty() || state.contains("not found") {
+        return Ok(String::new());
+    }
+
+    Ok(state)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_pr_state_values() {
+        // These are unit tests for parsing logic only
+        // Integration tests would require a real git repo and gh CLI
+
+        // Test that valid states are recognized
+        let valid_states = ["MERGED", "OPEN", "CLOSED"];
+        assert!(valid_states.contains(&"MERGED"));
+        assert!(valid_states.contains(&"OPEN"));
+        assert!(valid_states.contains(&"CLOSED"));
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,7 +1,10 @@
 //! Task implementations for xtask commands.
 //!
 //! Each function corresponds to a subcommand in the CLI.
-//! These are stubs that will be implemented in subsequent tickets.
+//! Implemented commands have their own modules; stubs remain for unimplemented
+//! ones.
+
+mod finish;
 
 use anyhow::{Result, bail};
 
@@ -55,12 +58,11 @@ pub fn check() -> Result<()> {
 
 /// Clean up after PR merge.
 ///
+/// Delegates to the finish module for the actual implementation.
+///
 /// # Errors
 ///
-/// Returns an error as this is not yet implemented.
+/// Returns an error if the cleanup fails. See [`finish::run`] for details.
 pub fn finish() -> Result<()> {
-    bail!(
-        "finish command not yet implemented\n\
-         This will be implemented in TCK-00028."
-    );
+    finish::run()
 }


### PR DESCRIPTION
## Summary

- Implement the `cargo xtask finish` command for cleaning up after PR merge
- Uses shared utilities from TCK-00027 for branch validation and worktree detection
- Verifies PR is merged via `gh pr view` before allowing cleanup
- Handles both worktree and main worktree scenarios

## Test plan

- [x] `cargo fmt --check -p xtask` passes
- [x] `cargo clippy -p xtask --all-targets -- -D warnings` passes  
- [x] `cargo test -p xtask` passes (15 tests)
- [x] `cargo xtask finish --help` shows correct usage

Manual testing:
- [ ] Run `cargo xtask finish` on a merged PR branch - should cleanup successfully
- [ ] Run `cargo xtask finish` on an open PR branch - should fail with helpful message
- [ ] Run `cargo xtask finish` on main branch - should fail with branch validation error

---
**Ticket:** TCK-00028
**RFC:** RFC-0002
**Depends on:** TCK-00027 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)