### PR TITLE
feat: derive ticket status from git state instead of YAML files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,9 @@ secrets.json
 
 # Development script state
 .check-eng-ticket-state
+
+# Ticket worktree metadata
+.ticket-state.json
+
+# Claude Code local config
+.claude/

--- a/documents/skills/development-loop/SKILL.md
+++ b/documents/skills/development-loop/SKILL.md
@@ -20,14 +20,12 @@ Read the output carefully. It provides all context needed to implement the ticke
 
 ### 3. Process Ticket
 
-a. **Update status** to `IN_PROGRESS` in `documents/work/tickets/{TICKET_ID}.yaml` (in main worktree)
-
-b. **Implement** following coding standards in `documents/coding/SKILL.md`:
+a. **Implement** following coding standards in `documents/coding/SKILL.md`:
    - Use the prompt from `references/IMPLEMENT_TICKET_PROMPT.md`
    - Substitute `$TICKET_ID` and `$RFC_ID` with actual values
    - Follow the implementation guidelines in that prompt
 
-c. **Run automated checks, sync your branch, and commit** using the commit command. Expect errors to occur during automated checks. We maintain an extremely high bar for code, and it is up to you to maintain that bar.:
+b. **Run automated checks, sync your branch, and commit** using the commit command. Expect errors to occur during automated checks. We maintain an extremely high bar for code, and it is up to you to maintain that bar.:
    ```bash
    cargo xtask commit "<description>"
    ```
@@ -71,7 +69,7 @@ For continuous monitoring: `cargo xtask check --watch`
    ```
 2. Return to step 2 (initialize next ticket)
 
-Note: Ticket status is automatically set to `IN_REVIEW` by the push command. A third party will verify and update to `COMPLETED` after merge.
+Note: Ticket status is derived from git state - branches indicate IN_PROGRESS, merged PRs indicate COMPLETED.
 
 ### 6. Complete
 
@@ -101,7 +99,7 @@ When all tickets are done (no more processable tickets in step 2), report comple
 | Worktree isolation | Prevents conflicts between parallel agents, enables independent CI |
 | Branch naming: `ticket/{RFC_ID}/{TICKET_ID}` | Traceable to RFC and ticket |
 | Worktree naming: `apm2-{TICKET_ID}` | Clear association with ticket |
-| Use ticket YAML `status` field | Persistent, auditable, already in data model |
+| Derive status from git state | Single source of truth, no manual updates needed |
 | Idempotent commands | Safe to re-run, handles existing state gracefully |
 | AI reviews via local CLIs | No self-hosted runners needed, uses local auth |
 | Status checks for merge gating | Reviews block merge until passed |

--- a/documents/standards/schemas/04_ticket_meta.schema.yaml
+++ b/documents/standards/schemas/04_ticket_meta.schema.yaml
@@ -12,7 +12,6 @@ ticket_meta_schema:
       required_keys:
         - "id"
         - "title"
-        - "status"
       keys:
         id:
           type: "string"
@@ -20,9 +19,6 @@ ticket_meta_schema:
         title:
           type: "string"
           min_length: 3
-        status:
-          type: "string"
-          enum_ref: "standards/enums/10_ticket_status.yaml#ticket_status.values"
     binds:
       type: "object"
       required_keys:

--- a/documents/work/tickets/STATUS_TRACKING.md
+++ b/documents/work/tickets/STATUS_TRACKING.md
@@ -1,0 +1,48 @@
+# Ticket Status Tracking
+
+Ticket status is derived dynamically from git state, not stored in YAML files.
+
+## Status Values
+
+| Status | Detection |
+|--------|-----------|
+| PENDING | No branch `ticket/*/TCK-XXXXX` exists |
+| IN_PROGRESS | Branch exists, PR not merged |
+| COMPLETED | PR merged for ticket branch |
+
+## How It Works
+
+1. `cargo xtask start-ticket` queries git branches and GitHub PRs
+2. Tickets with merged PRs are marked COMPLETED
+3. Tickets with existing branches are marked IN_PROGRESS
+4. Remaining tickets are PENDING (if dependencies are met)
+
+## Implementation Details
+
+The status determination is handled by `xtask/src/ticket_status.rs`:
+
+- `get_completed_tickets()` - Queries GitHub for merged PRs with ticket branch patterns
+- `get_in_progress_tickets()` - Lists all ticket branches (local and remote), filtering out completed ones
+
+## Benefits
+
+- No manual status updates required
+- Single source of truth (git state)
+- Status cannot become inconsistent
+- Works offline (with reduced functionality - completed tickets may show as pending)
+
+## Branch Naming Convention
+
+Ticket branches follow the pattern: `ticket/{RFC_ID}/{TICKET_ID}`
+
+Example: `ticket/RFC-0002/TCK-00030`
+
+## Migration Notes
+
+Previously, ticket status was stored in the `status` field of ticket YAML files. This was removed because:
+
+1. Status updates were error-prone and often forgotten
+2. `start-ticket` would pick up already-completed tickets
+3. Multiple sources of truth led to inconsistencies
+
+The git state is now the authoritative source for ticket status.

--- a/documents/work/tickets/TCK-00001.yaml
+++ b/documents/work/tickets/TCK-00001.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00001"
     title: "Implement ledger storage layer with SQLite WAL"
-    status: "COMPLETED"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00002.yaml
+++ b/documents/work/tickets/TCK-00002.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00002"
     title: "Define kernel event schemas with prost"
-    status: "COMPLETED"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00003.yaml
+++ b/documents/work/tickets/TCK-00003.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00003"
     title: "Implement hash-chain and signature primitives"
-    status: "COMPLETED"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00004.yaml
+++ b/documents/work/tickets/TCK-00004.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00004"
     title: "Implement reducer framework with checkpointing"
-    status: "COMPLETED"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00005.yaml
+++ b/documents/work/tickets/TCK-00005.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00005"
     title: "Implement session lifecycle state machine"
-    status: "COMPLETED"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00006.yaml
+++ b/documents/work/tickets/TCK-00006.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00006"
     title: "Implement entropy budget tracker"
-    status: "IN_PROGRESS"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00007.yaml
+++ b/documents/work/tickets/TCK-00007.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00007"
     title: "Implement crash detection and restart logic"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00008.yaml
+++ b/documents/work/tickets/TCK-00008.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00008"
     title: "Implement quarantine mechanism"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00009.yaml
+++ b/documents/work/tickets/TCK-00009.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00009"
     title: "Implement policy DSL parser"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00010.yaml
+++ b/documents/work/tickets/TCK-00010.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00010"
     title: "Implement default-deny evaluation engine"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00011.yaml
+++ b/documents/work/tickets/TCK-00011.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00011"
     title: "Implement budget enforcement"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00012.yaml
+++ b/documents/work/tickets/TCK-00012.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00012"
     title: "Implement audit event emission"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00013.yaml
+++ b/documents/work/tickets/TCK-00013.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00013"
     title: "Define tool request/response contract"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00014.yaml
+++ b/documents/work/tickets/TCK-00014.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00014"
     title: "Implement filesystem mediation adapter"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00015.yaml
+++ b/documents/work/tickets/TCK-00015.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00015"
     title: "Implement shell command mediation adapter"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00016.yaml
+++ b/documents/work/tickets/TCK-00016.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00016"
     title: "Implement inference syscall adapter"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00017.yaml
+++ b/documents/work/tickets/TCK-00017.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00017"
     title: "Implement work contract data model"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00018.yaml
+++ b/documents/work/tickets/TCK-00018.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00018"
     title: "Implement lease registrar"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00019.yaml
+++ b/documents/work/tickets/TCK-00019.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00019"
     title: "Implement evidence bundle publisher"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00020.yaml
+++ b/documents/work/tickets/TCK-00020.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00020"
     title: "Implement gate receipt generator"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00021.yaml
+++ b/documents/work/tickets/TCK-00021.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00021"
     title: "Implement black-box adapter (observation-based)"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00022.yaml
+++ b/documents/work/tickets/TCK-00022.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00022"
     title: "Implement Claude Code instrumented adapter"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00023.yaml
+++ b/documents/work/tickets/TCK-00023.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00023"
     title: "Implement factory run CLI command"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00024.yaml
+++ b/documents/work/tickets/TCK-00024.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00024"
     title: "End-to-end integration tests"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00025.yaml
+++ b/documents/work/tickets/TCK-00025.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00025"
     title: "Implement seccomp sandbox for black-box adapter"
-    status: "DRAFT"
   binds:
     prd_id: "PRD-0001"
     rfc_id: "RFC-0001"

--- a/documents/work/tickets/TCK-00026.yaml
+++ b/documents/work/tickets/TCK-00026.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00026"
     title: "Create xtask crate structure"
-    status: "COMPLETED"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/documents/work/tickets/TCK-00027.yaml
+++ b/documents/work/tickets/TCK-00027.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00027"
     title: "Implement shared utilities"
-    status: "COMPLETED"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/documents/work/tickets/TCK-00028.yaml
+++ b/documents/work/tickets/TCK-00028.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00028"
     title: "Implement finish command"
-    status: "IN_REVIEW"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/documents/work/tickets/TCK-00029.yaml
+++ b/documents/work/tickets/TCK-00029.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00029"
     title: "Implement check command"
-    status: "IN_REVIEW"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/documents/work/tickets/TCK-00030.yaml
+++ b/documents/work/tickets/TCK-00030.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00030"
     title: "Implement start-ticket command"
-    status: "IN_REVIEW"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/documents/work/tickets/TCK-00031.yaml
+++ b/documents/work/tickets/TCK-00031.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00031"
     title: "Implement commit command"
-    status: "IN_REVIEW"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/documents/work/tickets/TCK-00032.yaml
+++ b/documents/work/tickets/TCK-00032.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00032"
     title: "Implement push command"
-    status: "IN_REVIEW"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/documents/work/tickets/TCK-00033.yaml
+++ b/documents/work/tickets/TCK-00033.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00033"
     title: "Update docs and delete bash scripts"
-    status: "IN_PROGRESS"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/documents/work/tickets/TCK-00034.yaml
+++ b/documents/work/tickets/TCK-00034.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00034"
     title: "Implement review sign-off commands"
-    status: "IN_PROGRESS"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/documents/work/tickets/TCK-00035.yaml
+++ b/documents/work/tickets/TCK-00035.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00035"
     title: "Implement security review exec command"
-    status: "IN_PROGRESS"
   binds:
     prd_id: ""
     rfc_id: "RFC-0002"

--- a/documents/work/tickets/TCK-00040.yaml
+++ b/documents/work/tickets/TCK-00040.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00040"
     title: "Define Holon trait and core types"
-    status: "PENDING"
   binds:
     prd_id: ""
     rfc_id: "RFC-0003"

--- a/documents/work/tickets/TCK-00041.yaml
+++ b/documents/work/tickets/TCK-00041.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00041"
     title: "Implement WorkObject and lifecycle state machine"
-    status: "PENDING"
   binds:
     prd_id: ""
     rfc_id: "RFC-0003"

--- a/documents/work/tickets/TCK-00042.yaml
+++ b/documents/work/tickets/TCK-00042.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00042"
     title: "Implement Lease and Budget types"
-    status: "PENDING"
   binds:
     prd_id: ""
     rfc_id: "RFC-0003"

--- a/documents/work/tickets/TCK-00043.yaml
+++ b/documents/work/tickets/TCK-00043.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00043"
     title: "Implement LedgerEvent and chain verification"
-    status: "PENDING"
   binds:
     prd_id: ""
     rfc_id: "RFC-0003"

--- a/documents/work/tickets/TCK-00044.yaml
+++ b/documents/work/tickets/TCK-00044.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00044"
     title: "Implement EpisodeContext and stop conditions"
-    status: "PENDING"
   binds:
     prd_id: ""
     rfc_id: "RFC-0003"

--- a/documents/work/tickets/TCK-00045.yaml
+++ b/documents/work/tickets/TCK-00045.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00045"
     title: "Create spawn_holon orchestration function"
-    status: "PENDING"
   binds:
     prd_id: ""
     rfc_id: "RFC-0003"

--- a/documents/work/tickets/TCK-00046.yaml
+++ b/documents/work/tickets/TCK-00046.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00046"
     title: "Add holon: field to skill frontmatter schema"
-    status: "PENDING"
   binds:
     prd_id: ""
     rfc_id: "RFC-0003"

--- a/documents/work/tickets/TCK-00047.yaml
+++ b/documents/work/tickets/TCK-00047.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00047"
     title: "Create example-holon skill demonstrating pattern"
-    status: "PENDING"
   binds:
     prd_id: ""
     rfc_id: "RFC-0003"

--- a/documents/work/tickets/TCK-00048.yaml
+++ b/documents/work/tickets/TCK-00048.yaml
@@ -4,7 +4,6 @@ ticket_meta:
   ticket:
     id: "TCK-00048"
     title: "Update dev-rfc to use holon pattern"
-    status: "PENDING"
   binds:
     prd_id: ""
     rfc_id: "RFC-0003"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,6 +24,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 mod tasks;
+pub mod ticket_status;
 pub mod util;
 
 /// Development automation for apm2.

--- a/xtask/src/ticket_status.rs
+++ b/xtask/src/ticket_status.rs
@@ -1,0 +1,357 @@
+//! Dynamic ticket status determination from git state.
+//!
+//! This module provides functions to derive ticket status from git state
+//! (merged PRs, existing branches, worktrees) rather than reading from
+//! YAML files. This eliminates manual status maintenance bugs and creates
+//! a single source of truth.
+//!
+//! # Status Detection
+//!
+//! | Status | Detection |
+//! |--------|-----------|
+//! | `COMPLETED` | Branch `ticket/*/TCK-XXXXX` has merged PR |
+//! | `IN_PROGRESS` | Branch exists (local or remote), not merged |
+//! | `PENDING` | No branch exists, not completed |
+
+use std::collections::HashSet;
+
+use anyhow::Result;
+use xshell::{Shell, cmd};
+
+/// Ticket status derived from git state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TicketStatus {
+    /// No branch exists for this ticket.
+    Pending,
+    /// Branch exists but PR not merged.
+    InProgress,
+    /// PR has been merged.
+    Completed,
+}
+
+/// Get all completed ticket IDs by checking merged PRs.
+///
+/// Queries GitHub for merged PRs with ticket branch patterns like
+/// `ticket/RFC-*/TCK-XXXXX` and extracts the ticket IDs.
+///
+/// # Errors
+///
+/// Returns an error if the `gh` CLI command fails. If GitHub is unavailable,
+/// returns an empty set (allowing offline operation with reduced
+/// functionality).
+pub fn get_completed_tickets(sh: &Shell) -> Result<HashSet<String>> {
+    // Query GitHub for merged PRs with ticket branch pattern
+    // Use --limit 500 to get a reasonable history
+    let output = cmd!(
+        sh,
+        "gh pr list --state merged --limit 500 --json headRefName"
+    )
+    .read()
+    .unwrap_or_default();
+
+    Ok(parse_ticket_ids_from_pr_json(&output))
+}
+
+/// Get ticket IDs with active branches (not merged).
+///
+/// Lists all ticket branches (local and remote) and filters out
+/// those that have already been completed.
+///
+/// # Errors
+///
+/// Returns an error if git commands fail.
+#[allow(clippy::implicit_hasher)]
+pub fn get_in_progress_tickets(sh: &Shell, completed: &HashSet<String>) -> Result<HashSet<String>> {
+    // List all ticket branches (local and remote)
+    // Use --list with pattern to match ticket branches
+    let local_output = cmd!(sh, "git branch --list *ticket/*TCK-*")
+        .read()
+        .unwrap_or_default();
+
+    let remote_output = cmd!(sh, "git branch -r --list *ticket/*TCK-*")
+        .read()
+        .unwrap_or_default();
+
+    let combined = format!("{local_output}\n{remote_output}");
+    Ok(parse_ticket_ids_from_branch_list(&combined, completed))
+}
+
+/// Get ticket IDs with active worktrees.
+///
+/// Parses `git worktree list --porcelain` output to find worktrees
+/// with ticket-related paths like `/path/apm2-TCK-00030`.
+///
+/// # Errors
+///
+/// Returns an error if git commands fail.
+#[allow(dead_code)]
+pub fn get_worktree_tickets(sh: &Shell) -> Result<HashSet<String>> {
+    let output = cmd!(sh, "git worktree list --porcelain")
+        .read()
+        .unwrap_or_default();
+
+    Ok(parse_ticket_ids_from_worktrees(&output))
+}
+
+/// Parse ticket IDs from GitHub PR list JSON output.
+///
+/// Expects JSON format: `[{"headRefName": "ticket/RFC-0002/TCK-00030"}, ...]`
+fn parse_ticket_ids_from_pr_json(json: &str) -> HashSet<String> {
+    let mut ticket_ids = HashSet::new();
+    let key = "\"headRefName\":";
+
+    // Simple JSON parsing without serde dependency
+    // Find ALL occurrences of "headRefName" in the content
+    let mut search_pos = 0;
+    while let Some(start) = json[search_pos..].find(key) {
+        let abs_start = search_pos + start;
+        let rest = &json[abs_start + key.len()..];
+
+        // Find the value between quotes
+        if let Some(quote_start) = rest.find('"') {
+            let after_quote = &rest[quote_start + 1..];
+            if let Some(quote_end) = after_quote.find('"') {
+                let branch_name = &after_quote[..quote_end];
+                if let Some(ticket_id) = extract_ticket_id_from_branch(branch_name) {
+                    ticket_ids.insert(ticket_id);
+                }
+                // Move past this match
+                search_pos = abs_start + key.len() + quote_start + 1 + quote_end + 1;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    ticket_ids
+}
+
+/// Parse ticket IDs from git branch list output.
+///
+/// Expects output like:
+/// ```text
+///   ticket/RFC-0002/TCK-00030
+/// * ticket/RFC-0002/TCK-00031
+///   remotes/origin/ticket/RFC-0002/TCK-00032
+/// ```
+fn parse_ticket_ids_from_branch_list(output: &str, completed: &HashSet<String>) -> HashSet<String> {
+    let mut ticket_ids = HashSet::new();
+
+    for line in output.lines() {
+        let branch = line.trim().trim_start_matches("* ").trim();
+        // Remove remotes/origin/ prefix if present
+        let branch = branch.strip_prefix("remotes/origin/").unwrap_or(branch);
+
+        if let Some(ticket_id) = extract_ticket_id_from_branch(branch) {
+            // Only include if not already completed
+            if !completed.contains(&ticket_id) {
+                ticket_ids.insert(ticket_id);
+            }
+        }
+    }
+
+    ticket_ids
+}
+
+/// Parse ticket IDs from git worktree list --porcelain output.
+///
+/// Expects output like:
+/// ```text
+/// worktree /path/to/apm2
+/// HEAD abc123
+/// branch refs/heads/main
+///
+/// worktree /path/to/apm2-TCK-00030
+/// HEAD def456
+/// branch refs/heads/ticket/RFC-0002/TCK-00030
+/// ```
+fn parse_ticket_ids_from_worktrees(output: &str) -> HashSet<String> {
+    let mut ticket_ids = HashSet::new();
+
+    for line in output.lines() {
+        // Look for worktree paths containing TCK-XXXXX
+        if let Some(path) = line.strip_prefix("worktree ") {
+            // Extract TCK-XXXXX from path like /path/apm2-TCK-00030
+            if let Some(idx) = path.find("TCK-") {
+                let rest = &path[idx..];
+                // Extract just the TCK-XXXXX part (5 digits after TCK-)
+                if rest.len() >= 9 {
+                    let ticket_id = &rest[..9];
+                    if is_valid_ticket_id(ticket_id) {
+                        ticket_ids.insert(ticket_id.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    ticket_ids
+}
+
+/// Extract ticket ID from a branch name like `ticket/RFC-0002/TCK-00030`.
+fn extract_ticket_id_from_branch(branch: &str) -> Option<String> {
+    // Look for TCK-XXXXX pattern in the branch name
+    if let Some(idx) = branch.find("TCK-") {
+        let rest = &branch[idx..];
+        // Extract just the TCK-XXXXX part (5 digits after TCK-)
+        if rest.len() >= 9 {
+            let ticket_id = &rest[..9];
+            if is_valid_ticket_id(ticket_id) {
+                return Some(ticket_id.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Check if a string is a valid ticket ID (TCK-XXXXX where X is a digit).
+fn is_valid_ticket_id(s: &str) -> bool {
+    if !s.starts_with("TCK-") {
+        return false;
+    }
+    let digits = &s[4..];
+    digits.len() == 5 && digits.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Determine the status of a specific ticket.
+///
+/// # Arguments
+///
+/// * `ticket_id` - The ticket ID to check (e.g., "TCK-00030")
+/// * `completed` - Set of ticket IDs that are completed
+/// * `in_progress` - Set of ticket IDs that are in progress
+///
+/// # Returns
+///
+/// The derived `TicketStatus` for the ticket.
+#[allow(dead_code)]
+#[allow(clippy::implicit_hasher)]
+pub fn get_ticket_status(
+    ticket_id: &str,
+    completed: &HashSet<String>,
+    in_progress: &HashSet<String>,
+) -> TicketStatus {
+    if completed.contains(ticket_id) {
+        TicketStatus::Completed
+    } else if in_progress.contains(ticket_id) {
+        TicketStatus::InProgress
+    } else {
+        TicketStatus::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_ticket_id_from_branch() {
+        assert_eq!(
+            extract_ticket_id_from_branch("ticket/RFC-0002/TCK-00030"),
+            Some("TCK-00030".to_string())
+        );
+        assert_eq!(
+            extract_ticket_id_from_branch("TCK-00030"),
+            Some("TCK-00030".to_string())
+        );
+        assert_eq!(extract_ticket_id_from_branch("feature/something"), None);
+        assert_eq!(
+            extract_ticket_id_from_branch("ticket/RFC-0002/TCK-0003"), // Too short
+            None
+        );
+    }
+
+    #[test]
+    fn test_is_valid_ticket_id() {
+        assert!(is_valid_ticket_id("TCK-00030"));
+        assert!(is_valid_ticket_id("TCK-00001"));
+        assert!(is_valid_ticket_id("TCK-99999"));
+        assert!(!is_valid_ticket_id("TCK-0003")); // Too short
+        assert!(!is_valid_ticket_id("TCK-000030")); // Too long
+        assert!(!is_valid_ticket_id("TCK-0003a")); // Non-digit
+        assert!(!is_valid_ticket_id("TKT-00030")); // Wrong prefix
+    }
+
+    #[test]
+    fn test_parse_ticket_ids_from_pr_json() {
+        // Test multi-line format
+        let json = r#"[
+            {"headRefName":"ticket/RFC-0002/TCK-00030","number":1},
+            {"headRefName":"ticket/RFC-0002/TCK-00031","number":2},
+            {"headRefName":"feature/something","number":3}
+        ]"#;
+
+        let result = parse_ticket_ids_from_pr_json(json);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains("TCK-00030"));
+        assert!(result.contains("TCK-00031"));
+    }
+
+    #[test]
+    fn test_parse_ticket_ids_from_pr_json_single_line() {
+        // Test single-line format (as returned by gh CLI)
+        let json = r#"[{"headRefName":"RFC-0002/TCK-00034"},{"headRefName":"ticket/RFC-0003/TCK-00040"},{"headRefName":"ticket/RFC-0002/TCK-00033"}]"#;
+
+        let result = parse_ticket_ids_from_pr_json(json);
+        assert_eq!(result.len(), 3);
+        assert!(result.contains("TCK-00034"));
+        assert!(result.contains("TCK-00040"));
+        assert!(result.contains("TCK-00033"));
+    }
+
+    #[test]
+    fn test_parse_ticket_ids_from_branch_list() {
+        let output = r"
+  ticket/RFC-0002/TCK-00030
+* ticket/RFC-0002/TCK-00031
+  remotes/origin/ticket/RFC-0002/TCK-00032
+  feature/something
+";
+
+        let completed = HashSet::from(["TCK-00030".to_string()]);
+        let result = parse_ticket_ids_from_branch_list(output, &completed);
+
+        // TCK-00030 should be filtered out (completed)
+        assert_eq!(result.len(), 2);
+        assert!(!result.contains("TCK-00030"));
+        assert!(result.contains("TCK-00031"));
+        assert!(result.contains("TCK-00032"));
+    }
+
+    #[test]
+    fn test_parse_ticket_ids_from_worktrees() {
+        let output = r"worktree /home/user/apm2
+HEAD abc123
+branch refs/heads/main
+
+worktree /home/user/apm2-TCK-00030
+HEAD def456
+branch refs/heads/ticket/RFC-0002/TCK-00030
+";
+
+        let result = parse_ticket_ids_from_worktrees(output);
+        assert_eq!(result.len(), 1);
+        assert!(result.contains("TCK-00030"));
+    }
+
+    #[test]
+    fn test_get_ticket_status() {
+        let completed = HashSet::from(["TCK-00001".to_string()]);
+        let in_progress = HashSet::from(["TCK-00002".to_string()]);
+
+        assert_eq!(
+            get_ticket_status("TCK-00001", &completed, &in_progress),
+            TicketStatus::Completed
+        );
+        assert_eq!(
+            get_ticket_status("TCK-00002", &completed, &in_progress),
+            TicketStatus::InProgress
+        );
+        assert_eq!(
+            get_ticket_status("TCK-00003", &completed, &in_progress),
+            TicketStatus::Pending
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Remove the `status` field from ticket YAML files and derive status dynamically from git state
- COMPLETED: Branch `ticket/*/TCK-XXXXX` has merged PR
- IN_PROGRESS: Branch exists (local or remote), not merged
- PENDING: No branch exists

This eliminates manual status maintenance bugs where tickets remained PENDING after PRs were merged, causing `start-ticket` to pick up already-completed tickets.

## Changes

- Add `xtask/src/ticket_status.rs` with functions to query GitHub PRs and git branches
- Update `start_ticket.rs` to use dynamic status from the new module
- Remove `status` from ticket schema (`04_ticket_meta.schema.yaml`)
- Remove `status` field from all 44 ticket YAML files
- Add `STATUS_TRACKING.md` documentation
- Update `SKILL.md` to reflect dynamic status tracking

## Test plan

- [x] All 64 xtask tests pass
- [x] Clippy passes with no warnings
- [x] `cargo xtask start-ticket RFC-0003` correctly identifies TCK-00041 (dependency TCK-00040 has merged PR)
- [x] `cargo xtask start-ticket RFC-0002` correctly skips completed tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)