### PR TITLE
docs(RFC-0005): add engineering tickets TCK-00055 through TCK-00058

### DIFF
--- a/documents/work/tickets/TCK-00055.yaml
+++ b/documents/work/tickets/TCK-00055.yaml
@@ -1,0 +1,60 @@
+ticket_meta:
+  schema_version: "2026-01-24"
+  template_version: "2026-01-24"
+  ticket:
+    id: "TCK-00055"
+    title: "Fix CI failure detection in xtask check"
+  binds:
+    prd_id: "NONE"
+    rfc_id: "RFC-0005"
+    requirements:
+      - requirement_id: "MAINT-001"
+        requirement_ref: "documents/rfcs/RFC-0005/01_problem_and_imports.yaml#rfc_local_requirements.requirements[0]"
+    evidence_artifacts: []
+  custody:
+    agent_roles:
+      - "AGENT_IMPLEMENTER"
+    responsibility_domains:
+      - "DOMAIN_BUILD_RELEASE"
+  dependencies:
+    tickets: []
+  scope:
+    in_scope:
+      - "Add CheckRun struct with serde derives for JSON parsing"
+      - "Replace string matching with serde_json deserialization in get_ci_status()"
+      - "Handle conclusion field values: SUCCESS, FAILURE, CANCELLED, TIMED_OUT, SKIPPED, NEUTRAL, ACTION_REQUIRED, null"
+      - "Handle state field values: PENDING, IN_PROGRESS, QUEUED, COMPLETED"
+      - "Return appropriate CiStatus based on parsed data"
+      - "Add unit tests for JSON parsing edge cases"
+      - "Handle gh CLI warnings before JSON output gracefully"
+    out_of_scope:
+      - "Changes to other xtask commands"
+      - "GitHub API changes"
+      - "Branch protection rule changes"
+  plan:
+    steps:
+      - "Define CheckRun struct with name, state, conclusion fields"
+      - "Add serde derives: Deserialize, Debug"
+      - "Make conclusion field Option<String> to handle null values"
+      - "Replace string matching logic with serde_json::from_str::<Vec<CheckRun>>()"
+      - "Iterate parsed checks to determine overall status"
+      - "If any check has conclusion=FAILURE, return CiStatus::Failed"
+      - "If any check has state != COMPLETED, return CiStatus::Running"
+      - "If all checks have conclusion=SUCCESS, return CiStatus::Passed"
+      - "Add unit tests for: empty array, null conclusion, missing fields, FAILURE case"
+      - "Test with actual PR to verify fix"
+  definition_of_done:
+    evidence_ids: []
+    criteria:
+      - "cargo xtask check correctly identifies failed CI checks"
+      - "Output shows '[X] CI checks failed' when CI has failed"
+      - "Exit code is non-zero when CI has failed"
+      - "JSON parsing handles missing/optional fields gracefully"
+      - "No 'Unknown JSON field' warnings in output"
+      - "cargo build succeeds"
+      - "cargo test passes"
+      - "cargo clippy passes with no warnings"
+  notes:
+    security: "No security impact - read-only status checking"
+    root_cause: "String matching on JSON output is fragile; serde deserialization is robust"
+    affected_file: "xtask/src/tasks/check.rs lines 215-248 (get_ci_status function)"

--- a/documents/work/tickets/TCK-00056.yaml
+++ b/documents/work/tickets/TCK-00056.yaml
@@ -1,0 +1,55 @@
+ticket_meta:
+  schema_version: "2026-01-24"
+  template_version: "2026-01-24"
+  ticket:
+    id: "TCK-00056"
+    title: "Fix AI review status creation in xtask push"
+  binds:
+    prd_id: "NONE"
+    rfc_id: "RFC-0005"
+    requirements:
+      - requirement_id: "MAINT-002"
+        requirement_ref: "documents/rfcs/RFC-0005/01_problem_and_imports.yaml#rfc_local_requirements.requirements[1]"
+    evidence_artifacts: []
+  custody:
+    agent_roles:
+      - "AGENT_IMPLEMENTER"
+    responsibility_domains:
+      - "DOMAIN_BUILD_RELEASE"
+  dependencies:
+    tickets: []
+  scope:
+    in_scope:
+      - "Fix create_pending_statuses function in xtask/src/tasks/push.rs"
+      - "Use separate variables for multi-word -f values in gh api calls"
+      - "Check actual command output/status, not just .is_ok()"
+      - "Report errors to user when status creation fails"
+      - "Verify status creation via GitHub API after creation"
+    out_of_scope:
+      - "Changes to other xtask commands"
+      - "New status types"
+      - "GitHub API changes"
+  plan:
+    steps:
+      - "Extract description strings into variables before cmd! macro"
+      - "Use interpolated variables in cmd! for description field"
+      - "Change from .is_ok() to proper error handling with .run()"
+      - "Capture command stderr/stdout for error reporting"
+      - "Print actual error message when status creation fails"
+      - "Verify with gh api call that status was actually created"
+      - "Add integration test that checks status exists after creation"
+  definition_of_done:
+    evidence_ids: []
+    criteria:
+      - "cargo xtask push creates ai-review/security status on GitHub"
+      - "cargo xtask push creates ai-review/code-quality status on GitHub"
+      - "Statuses visible via: gh api /repos/{owner}/{repo}/commits/{sha}/statuses"
+      - "Errors reported when status creation fails (no silent failures)"
+      - "gh api arguments correctly escaped for multi-word description values"
+      - "cargo build succeeds"
+      - "cargo test passes"
+      - "cargo clippy passes with no warnings"
+  notes:
+    security: "Uses gh CLI for API calls - credentials managed externally"
+    root_cause: "xshell cmd! macro splits multi-word strings; use variables for interpolation"
+    affected_file: "xtask/src/tasks/push.rs lines 366-390 (create_pending_statuses function)"

--- a/documents/work/tickets/TCK-00057.yaml
+++ b/documents/work/tickets/TCK-00057.yaml
@@ -1,0 +1,58 @@
+ticket_meta:
+  schema_version: "2026-01-24"
+  template_version: "2026-01-24"
+  ticket:
+    id: "TCK-00057"
+    title: "Fix Codex CLI invocation in xtask review"
+  binds:
+    prd_id: "NONE"
+    rfc_id: "RFC-0005"
+    requirements:
+      - requirement_id: "MAINT-003"
+        requirement_ref: "documents/rfcs/RFC-0005/01_problem_and_imports.yaml#rfc_local_requirements.requirements[2]"
+    evidence_artifacts: []
+  custody:
+    agent_roles:
+      - "AGENT_IMPLEMENTER"
+    responsibility_domains:
+      - "DOMAIN_BUILD_RELEASE"
+  dependencies:
+    tickets: []
+  scope:
+    in_scope:
+      - "Fix run_ai_review function in xtask/src/tasks/review.rs"
+      - "Replace invalid Codex CLI invocation with correct syntax"
+      - "Use 'codex review --base main' instead of invalid flags"
+      - "Update push.rs trigger_ai_reviews to use consistent Codex invocation"
+      - "Add better error handling for Codex execution"
+      - "Gracefully handle case when Codex CLI is not installed"
+    out_of_scope:
+      - "Changes to Codex CLI itself"
+      - "New review types"
+      - "Alternative AI review tools"
+  plan:
+    steps:
+      - "Review current Codex invocation in review.rs:291-293"
+      - "Replace .args(['-m', 'o3', '--approval-mode', 'full-auto', ...]) with correct args"
+      - "Use 'codex review --base main' subcommand"
+      - "Review push.rs:324-325 for same pattern and fix"
+      - "Add error handling for 'codex not found' case"
+      - "Print helpful message if Codex is not installed"
+      - "Test with actual PR to verify review executes"
+  definition_of_done:
+    evidence_ids: []
+    criteria:
+      - "cargo xtask review quality <PR_URL> runs without argument errors"
+      - "No 'unexpected argument --approval-mode' errors"
+      - "Codex review executes successfully when Codex CLI is available"
+      - "Graceful error message when Codex CLI is not installed"
+      - "Review posts comment or updates status on PR"
+      - "cargo build succeeds"
+      - "cargo test passes"
+      - "cargo clippy passes with no warnings"
+  notes:
+    security: "Codex CLI handles its own authentication"
+    root_cause: "Invalid Codex CLI flags used; --approval-mode does not exist"
+    affected_files:
+      - "xtask/src/tasks/review.rs lines 291-293"
+      - "xtask/src/tasks/push.rs lines 324-325"

--- a/documents/work/tickets/TCK-00058.yaml
+++ b/documents/work/tickets/TCK-00058.yaml
@@ -1,0 +1,64 @@
+ticket_meta:
+  schema_version: "2026-01-24"
+  template_version: "2026-01-24"
+  ticket:
+    id: "TCK-00058"
+    title: "Add pre-commit checks to xtask commit"
+  binds:
+    prd_id: "NONE"
+    rfc_id: "RFC-0005"
+    requirements:
+      - requirement_id: "MAINT-004"
+        requirement_ref: "documents/rfcs/RFC-0005/01_problem_and_imports.yaml#rfc_local_requirements.requirements[3]"
+    evidence_artifacts: []
+  custody:
+    agent_roles:
+      - "AGENT_IMPLEMENTER"
+    responsibility_domains:
+      - "DOMAIN_BUILD_RELEASE"
+  dependencies:
+    tickets: []
+  scope:
+    in_scope:
+      - "Enhance xtask/src/tasks/commit.rs to run local checks before commit"
+      - "Run cargo fmt --check and fail if formatting issues found"
+      - "Run cargo clippy --all-targets -- -D warnings for lint checks"
+      - "Run cargo semver-checks if available (warn if not installed)"
+      - "Add --skip-checks flag to bypass checks when needed"
+      - "Display clear error messages indicating which check failed"
+      - "Provide suggestions for how to fix each type of failure"
+    out_of_scope:
+      - "Changes to other xtask commands"
+      - "Git hooks integration"
+      - "CI workflow changes"
+      - "New lint rules"
+  plan:
+    steps:
+      - "Add --skip-checks flag to commit command CLI definition"
+      - "Create run_pre_commit_checks() function"
+      - "Implement fmt check: cargo fmt --check"
+      - "Implement clippy check: cargo clippy --all-targets -- -D warnings"
+      - "Implement semver check: cargo semver-checks (with availability check)"
+      - "Print clear status for each check: [ok] or [X]"
+      - "If any check fails, print fix suggestion and exit with error"
+      - "If --skip-checks is set, skip all checks with warning message"
+      - "Only proceed to git commit if all checks pass (or skipped)"
+      - "Add unit tests for check execution logic"
+  definition_of_done:
+    evidence_ids: []
+    criteria:
+      - "cargo xtask commit runs fmt check before commit"
+      - "cargo xtask commit runs clippy check before commit"
+      - "cargo xtask commit runs semver-checks before commit (if available)"
+      - "Commit fails if any check fails (unless --skip-checks)"
+      - "--skip-checks flag bypasses all pre-commit checks with warning"
+      - "Clear output showing which check failed and how to fix"
+      - "Warn if cargo-semver-checks is not installed (don't fail)"
+      - "cargo build succeeds"
+      - "cargo test passes"
+      - "cargo clippy passes with no warnings"
+  notes:
+    security: "No security impact - local development checks only"
+    type: "ENHANCEMENT - preventive measure to catch issues before CI"
+    rationale: "Fail-fast principle improves developer productivity by catching issues locally"
+    affected_file: "xtask/src/tasks/commit.rs"


### PR DESCRIPTION
## Summary
- Create 4 engineering ticket YAML files for RFC-0005 (xtask workflow bug fixes)
- TCK-00055: Fix CI failure detection in xtask check (MAINT-001)
- TCK-00056: Fix AI review status creation in xtask push (MAINT-002)
- TCK-00057: Fix Codex CLI invocation in xtask review (MAINT-003)
- TCK-00058: Add pre-commit checks to xtask commit (MAINT-004)

## Test plan
- [x] All ticket files follow schema from template
- [x] Requirements correctly reference RFC-0005 local requirements
- [x] Scope and definition of done are complete for each ticket
- [x] No dependencies between tickets (parallel execution possible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)