### PR TITLE
feat(TCK-00057): fix codex cli invocation in xtask review

### DIFF
--- a/xtask/src/tasks/push.rs
+++ b/xtask/src/tasks/push.rs
@@ -346,9 +346,10 @@ fn trigger_ai_reviews(sh: &Shell, pr_url: &str) -> Result<()> {
     let codex_available = cmd!(sh, "which codex").ignore_status().read().is_ok();
     if codex_available && Path::new(&code_quality_prompt_path).exists() {
         println!("  Spawning Codex code quality review...");
-        // Spawn Codex review in background using the review subcommand
+        // Spawn Codex review in background using the review subcommand.
+        // The review subcommand runs non-interactively by default.
         let _ = std::process::Command::new("sh")
-            .args(["-c", "codex review --base main -c 'full_auto=true' &"])
+            .args(["-c", "codex review --base main &"])
             .spawn();
         println!("    Code quality review started in background");
     } else if !codex_available {

--- a/xtask/src/tasks/review.rs
+++ b/xtask/src/tasks/review.rs
@@ -302,9 +302,10 @@ fn run_ai_review(
             }
         },
         ReviewType::Quality => {
-            // Codex uses the 'review' subcommand to review changes against base branch
+            // Codex uses the 'review' subcommand to review changes against base branch.
+            // The review subcommand runs non-interactively by default.
             let result = std::process::Command::new("codex")
-                .args(["review", "--base", "main", "-c", "full_auto=true"])
+                .args(["review", "--base", "main"])
                 .status();
 
             match result {


### PR DESCRIPTION
## Summary

Implements ticket TCK-00057 as part of the xtask development automation.

## Ticket

See `documents/work/tickets/TCK-00057.yaml` for requirements.

## Test Plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test -p xtask` passes
- [ ] Manual testing of the new command
