### PR TITLE
feat(TCK-00009): implement policy dsl parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror",
  "tokio",

--- a/crates/apm2-core/Cargo.toml
+++ b/crates/apm2-core/Cargo.toml
@@ -19,6 +19,7 @@ tokio.workspace = true
 # Serialization
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 toml.workspace = true
 
 # Error handling

--- a/crates/apm2-core/src/lib.rs
+++ b/crates/apm2-core/src/lib.rs
@@ -44,6 +44,7 @@ pub mod ipc;
 pub mod lease;
 pub mod ledger;
 pub mod log;
+pub mod policy;
 pub mod process;
 pub mod reducer;
 pub mod restart;

--- a/crates/apm2-core/src/policy/error.rs
+++ b/crates/apm2-core/src/policy/error.rs
@@ -1,0 +1,175 @@
+//! Policy-specific error types.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Errors that can occur during policy operations.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PolicyError {
+    /// Failed to read policy file.
+    #[error("failed to read policy file at {path}: {source}")]
+    ReadError {
+        /// The path that could not be read.
+        path: PathBuf,
+        /// The underlying IO error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Failed to parse policy YAML.
+    #[error("failed to parse policy YAML: {0}")]
+    ParseError(#[from] serde_yaml::Error),
+
+    /// Policy validation failed.
+    #[error("policy validation failed: {message}")]
+    ValidationError {
+        /// Description of the validation failure.
+        message: String,
+    },
+
+    /// Invalid policy version.
+    #[error("invalid policy version: {version}, expected format: MAJOR.MINOR.PATCH")]
+    InvalidVersion {
+        /// The invalid version string.
+        version: String,
+    },
+
+    /// Invalid rule type.
+    #[error("invalid rule type: {value}")]
+    InvalidRuleType {
+        /// The invalid rule type value.
+        value: String,
+    },
+
+    /// Invalid decision.
+    #[error("invalid decision: {value}, expected ALLOW or DENY")]
+    InvalidDecision {
+        /// The invalid decision value.
+        value: String,
+    },
+
+    /// Invalid budget type.
+    #[error("invalid budget type: {value}")]
+    InvalidBudgetType {
+        /// The invalid budget type value.
+        value: String,
+    },
+
+    /// Duplicate rule ID.
+    #[error("duplicate rule ID: {rule_id}")]
+    DuplicateRuleId {
+        /// The duplicate rule ID.
+        rule_id: String,
+    },
+
+    /// Empty policy (no rules).
+    #[error("policy must contain at least one rule")]
+    EmptyPolicy,
+
+    /// Missing required field.
+    #[error("missing required field: {field}")]
+    MissingField {
+        /// The name of the missing field.
+        field: String,
+    },
+
+    /// Invalid glob pattern.
+    #[error("invalid glob pattern in rule {rule_id}: {pattern}: {reason}")]
+    InvalidGlobPattern {
+        /// The rule containing the invalid pattern.
+        rule_id: String,
+        /// The invalid pattern.
+        pattern: String,
+        /// Why it's invalid.
+        reason: String,
+    },
+
+    /// Circular dependency detected in rule conditions.
+    #[error("circular dependency detected in rule conditions involving {rule_id}")]
+    CircularDependency {
+        /// The rule involved in the cycle.
+        rule_id: String,
+    },
+}
+
+impl PolicyError {
+    /// Creates a validation error with the given message.
+    #[must_use]
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self::ValidationError {
+            message: message.into(),
+        }
+    }
+
+    /// Creates a missing field error.
+    #[must_use]
+    pub fn missing_field(field: impl Into<String>) -> Self {
+        Self::MissingField {
+            field: field.into(),
+        }
+    }
+
+    /// Creates a duplicate rule ID error.
+    #[must_use]
+    pub fn duplicate_rule_id(rule_id: impl Into<String>) -> Self {
+        Self::DuplicateRuleId {
+            rule_id: rule_id.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validation_error_display() {
+        let err = PolicyError::validation("rule order is invalid");
+        assert_eq!(
+            err.to_string(),
+            "policy validation failed: rule order is invalid"
+        );
+    }
+
+    #[test]
+    fn test_missing_field_error_display() {
+        let err = PolicyError::missing_field("version");
+        assert_eq!(err.to_string(), "missing required field: version");
+    }
+
+    #[test]
+    fn test_duplicate_rule_id_error_display() {
+        let err = PolicyError::duplicate_rule_id("RULE-001");
+        assert_eq!(err.to_string(), "duplicate rule ID: RULE-001");
+    }
+
+    #[test]
+    fn test_invalid_version_error_display() {
+        let err = PolicyError::InvalidVersion {
+            version: "v1".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid policy version: v1, expected format: MAJOR.MINOR.PATCH"
+        );
+    }
+
+    #[test]
+    fn test_invalid_decision_error_display() {
+        let err = PolicyError::InvalidDecision {
+            value: "MAYBE".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid decision: MAYBE, expected ALLOW or DENY"
+        );
+    }
+
+    #[test]
+    fn test_empty_policy_error_display() {
+        let err = PolicyError::EmptyPolicy;
+        assert_eq!(err.to_string(), "policy must contain at least one rule");
+    }
+}

--- a/crates/apm2-core/src/policy/event.rs
+++ b/crates/apm2-core/src/policy/event.rs
@@ -1,0 +1,126 @@
+//! Policy event generation.
+//!
+//! This module provides functions for creating policy-related kernel events,
+//! specifically the `PolicyLoaded` event that is emitted when a policy is
+//! loaded at startup.
+
+use super::parser::LoadedPolicy;
+use crate::events::{PolicyEvent, PolicyLoaded, policy_event};
+
+/// Creates a `PolicyLoaded` event from a loaded policy.
+///
+/// The event includes:
+/// - The BLAKE3 hash of the policy content
+/// - The policy version string
+/// - The number of rules in the policy
+#[must_use]
+pub fn create_policy_loaded_event(loaded: &LoadedPolicy) -> PolicyEvent {
+    PolicyEvent {
+        event: Some(policy_event::Event::Loaded(PolicyLoaded {
+            policy_hash: loaded.content_hash.to_vec(),
+            policy_version: loaded.policy.version.clone(),
+            rule_count: loaded.rule_count() as u64,
+        })),
+    }
+}
+
+/// Creates a `PolicyLoaded` event directly from components.
+///
+/// This is useful when you have the individual components rather than
+/// a `LoadedPolicy` struct.
+#[must_use]
+#[allow(clippy::missing_const_for_fn)] // Cannot be const due to heap allocations in Option
+pub fn create_policy_loaded_event_from_parts(
+    policy_hash: Vec<u8>,
+    policy_version: String,
+    rule_count: u64,
+) -> PolicyEvent {
+    PolicyEvent {
+        event: Some(policy_event::Event::Loaded(PolicyLoaded {
+            policy_hash,
+            policy_version,
+            rule_count,
+        })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_POLICY_YAML: &str = r#"
+policy:
+  version: "1.0.0"
+  name: "test-policy"
+  rules:
+    - id: "RULE-001"
+      type: tool_allow
+      tool: "fs.read"
+      decision: allow
+  default_decision: deny
+"#;
+
+    #[test]
+    fn test_create_policy_loaded_event() {
+        let loaded = LoadedPolicy::from_yaml(VALID_POLICY_YAML).unwrap();
+        let event = create_policy_loaded_event(&loaded);
+
+        match event.event {
+            Some(policy_event::Event::Loaded(loaded_event)) => {
+                assert_eq!(loaded_event.policy_hash.len(), 32);
+                assert_eq!(loaded_event.policy_version, "1.0.0");
+                assert_eq!(loaded_event.rule_count, 1);
+            },
+            _ => panic!("Expected PolicyLoaded event"),
+        }
+    }
+
+    #[test]
+    fn test_create_policy_loaded_event_hash_matches() {
+        let loaded = LoadedPolicy::from_yaml(VALID_POLICY_YAML).unwrap();
+        let event = create_policy_loaded_event(&loaded);
+
+        match event.event {
+            Some(policy_event::Event::Loaded(loaded_event)) => {
+                assert_eq!(loaded_event.policy_hash, loaded.content_hash.to_vec());
+            },
+            _ => panic!("Expected PolicyLoaded event"),
+        }
+    }
+
+    #[test]
+    fn test_create_policy_loaded_event_from_parts() {
+        let hash = vec![0u8; 32];
+        let version = "2.0.0".to_string();
+        let rule_count = 5;
+
+        let event =
+            create_policy_loaded_event_from_parts(hash.clone(), version.clone(), rule_count);
+
+        match event.event {
+            Some(policy_event::Event::Loaded(loaded_event)) => {
+                assert_eq!(loaded_event.policy_hash, hash);
+                assert_eq!(loaded_event.policy_version, version);
+                assert_eq!(loaded_event.rule_count, rule_count);
+            },
+            _ => panic!("Expected PolicyLoaded event"),
+        }
+    }
+
+    #[test]
+    fn test_policy_loaded_event_deterministic() {
+        // Same policy content should produce same hash in event
+        let loaded1 = LoadedPolicy::from_yaml(VALID_POLICY_YAML).unwrap();
+        let loaded2 = LoadedPolicy::from_yaml(VALID_POLICY_YAML).unwrap();
+
+        let event1 = create_policy_loaded_event(&loaded1);
+        let event2 = create_policy_loaded_event(&loaded2);
+
+        match (&event1.event, &event2.event) {
+            (Some(policy_event::Event::Loaded(e1)), Some(policy_event::Event::Loaded(e2))) => {
+                assert_eq!(e1.policy_hash, e2.policy_hash);
+            },
+            _ => panic!("Expected PolicyLoaded events"),
+        }
+    }
+}

--- a/crates/apm2-core/src/policy/mod.rs
+++ b/crates/apm2-core/src/policy/mod.rs
@@ -1,0 +1,93 @@
+//! Policy DSL parser for APM2.
+//!
+//! This module provides the policy configuration infrastructure for the APM2
+//! kernel. Policies define the rules that govern agent behavior through a
+//! default-deny model.
+//!
+//! # Overview
+//!
+//! Policies are YAML documents that specify:
+//! - **Tool access rules**: Which tools agents can use and on what resources
+//! - **Budget limits**: Caps on tokens, time, or operation counts
+//! - **Network access**: Allowed hosts and ports
+//! - **Filesystem access**: Path patterns that can be accessed
+//! - **Secrets access**: Which secrets can be accessed
+//! - **Inference access**: Model and provider restrictions
+//!
+//! # Default-Deny Model
+//!
+//! All policies operate on a default-deny principle:
+//! - Actions not explicitly allowed are denied
+//! - Rules are evaluated in order; first matching rule determines outcome
+//! - The `default_decision` should always be `deny`
+//!
+//! # Policy Schema
+//!
+//! ```yaml
+//! policy:
+//!   version: "1.0.0"
+//!   name: "my-policy"
+//!   description: "Optional description"
+//!   rules:
+//!     - id: "unique-rule-id"
+//!       type: tool_allow | tool_deny | budget | network | filesystem | secrets | inference
+//!       decision: allow | deny
+//!       # Type-specific fields...
+//!   default_decision: deny
+//! ```
+//!
+//! # Example
+//!
+//! ```rust
+//! use apm2_core::policy::{LoadedPolicy, create_policy_loaded_event};
+//!
+//! let yaml = r#"
+//! policy:
+//!   version: "1.0.0"
+//!   name: "example"
+//!   rules:
+//!     - id: "allow-fs-read"
+//!       type: tool_allow
+//!       tool: "fs.read"
+//!       paths:
+//!         - "/workspace/**"
+//!       decision: allow
+//!   default_decision: deny
+//! "#;
+//!
+//! let loaded = LoadedPolicy::from_yaml(yaml).unwrap();
+//! println!(
+//!     "Loaded policy '{}' with {} rules",
+//!     loaded.name(),
+//!     loaded.rule_count()
+//! );
+//! println!("Policy hash: {}", loaded.content_hash_hex());
+//!
+//! // Create a PolicyLoaded event for the ledger
+//! let event = create_policy_loaded_event(&loaded);
+//! ```
+//!
+//! # Security Properties
+//!
+//! - **Deterministic evaluation**: Same policy hash guarantees same decisions
+//! - **Content-addressed**: Policies are identified by BLAKE3 hash
+//! - **Validation**: All policies are validated before use
+//! - **Fail-closed**: Invalid policies are rejected; default is deny
+
+mod error;
+mod event;
+mod parser;
+mod schema;
+mod validator;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::PolicyError;
+pub use event::{create_policy_loaded_event, create_policy_loaded_event_from_parts};
+pub use parser::{
+    LoadedPolicy, compute_policy_hash, load_and_validate_policy_from_file, load_policy_from_file,
+    parse_and_validate_policy, parse_policy,
+};
+pub use schema::{BudgetType, Decision, Policy, PolicyDocument, PolicyVersion, Rule, RuleType};
+pub use validator::{ValidatedPolicy, validate_policy};

--- a/crates/apm2-core/src/policy/parser.rs
+++ b/crates/apm2-core/src/policy/parser.rs
@@ -1,0 +1,327 @@
+//! Policy parsing and loading.
+//!
+//! This module provides functions for parsing policy documents from YAML
+//! strings and loading them from files.
+
+use std::path::Path;
+
+use super::error::PolicyError;
+use super::schema::{Policy, PolicyDocument};
+use super::validator::{ValidatedPolicy, validate_policy};
+
+/// Parses a policy document from a YAML string.
+///
+/// # Errors
+///
+/// Returns `PolicyError::ParseError` if the YAML is invalid or doesn't match
+/// the expected schema.
+pub fn parse_policy(yaml: &str) -> Result<Policy, PolicyError> {
+    let doc: PolicyDocument = serde_yaml::from_str(yaml)?;
+    Ok(doc.policy)
+}
+
+/// Parses and validates a policy document from a YAML string.
+///
+/// This is the primary entry point for loading policy documents. It both
+/// parses the YAML and validates the policy structure.
+///
+/// # Errors
+///
+/// Returns `PolicyError` if parsing or validation fails.
+pub fn parse_and_validate_policy(yaml: &str) -> Result<(Policy, ValidatedPolicy), PolicyError> {
+    let policy = parse_policy(yaml)?;
+    let validated = validate_policy(&policy)?;
+    Ok((policy, validated))
+}
+
+/// Loads a policy document from a file path.
+///
+/// # Errors
+///
+/// Returns `PolicyError::ReadError` if the file cannot be read, or
+/// `PolicyError::ParseError` if the YAML is invalid.
+pub fn load_policy_from_file(path: &Path) -> Result<Policy, PolicyError> {
+    let content = std::fs::read_to_string(path).map_err(|e| PolicyError::ReadError {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    parse_policy(&content)
+}
+
+/// Loads and validates a policy document from a file path.
+///
+/// # Errors
+///
+/// Returns `PolicyError` if reading, parsing, or validation fails.
+pub fn load_and_validate_policy_from_file(
+    path: &Path,
+) -> Result<(Policy, ValidatedPolicy), PolicyError> {
+    let content = std::fs::read_to_string(path).map_err(|e| PolicyError::ReadError {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    parse_and_validate_policy(&content)
+}
+
+/// Computes a BLAKE3 hash of the policy content.
+///
+/// This hash is used to identify policy versions and is included in
+/// `PolicyLoaded` events for deterministic policy evaluation.
+#[must_use]
+pub fn compute_policy_hash(content: &str) -> [u8; 32] {
+    *blake3::hash(content.as_bytes()).as_bytes()
+}
+
+/// Represents a loaded policy with its content hash.
+#[derive(Debug, Clone)]
+pub struct LoadedPolicy {
+    /// The parsed policy.
+    pub policy: Policy,
+    /// Validation summary.
+    pub validated: ValidatedPolicy,
+    /// BLAKE3 hash of the original content.
+    pub content_hash: [u8; 32],
+}
+
+impl LoadedPolicy {
+    /// Creates a new loaded policy from YAML content.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PolicyError` if parsing or validation fails.
+    pub fn from_yaml(yaml: &str) -> Result<Self, PolicyError> {
+        let (policy, validated) = parse_and_validate_policy(yaml)?;
+        let content_hash = compute_policy_hash(yaml);
+        Ok(Self {
+            policy,
+            validated,
+            content_hash,
+        })
+    }
+
+    /// Loads a policy from a file path.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PolicyError` if reading, parsing, or validation fails.
+    pub fn from_file(path: &Path) -> Result<Self, PolicyError> {
+        let content = std::fs::read_to_string(path).map_err(|e| PolicyError::ReadError {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+        Self::from_yaml(&content)
+    }
+
+    /// Returns the policy version string.
+    #[must_use]
+    pub fn version(&self) -> &str {
+        &self.policy.version
+    }
+
+    /// Returns the policy name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.policy.name
+    }
+
+    /// Returns the number of rules in the policy.
+    #[must_use]
+    pub fn rule_count(&self) -> usize {
+        self.policy.rules.len()
+    }
+
+    /// Returns the content hash as a hex string.
+    #[must_use]
+    pub fn content_hash_hex(&self) -> String {
+        hex_encode(&self.content_hash)
+    }
+}
+
+/// Encodes bytes as a lowercase hexadecimal string.
+fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut acc, b| {
+            // write! to a String never fails
+            let _ = write!(acc, "{b:02x}");
+            acc
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::schema::{Decision, RuleType};
+
+    const VALID_POLICY_YAML: &str = r#"
+policy:
+  version: "1.0.0"
+  name: "test-policy"
+  description: "A test policy"
+  rules:
+    - id: "RULE-001"
+      type: tool_allow
+      tool: "fs.read"
+      paths:
+        - "/workspace/**"
+      decision: allow
+    - id: "RULE-002"
+      type: budget
+      budget_type: token
+      limit: 100000
+      decision: allow
+  default_decision: deny
+"#;
+
+    #[test]
+    fn test_parse_valid_policy() {
+        let policy = parse_policy(VALID_POLICY_YAML).unwrap();
+
+        assert_eq!(policy.version, "1.0.0");
+        assert_eq!(policy.name, "test-policy");
+        assert_eq!(policy.description, Some("A test policy".to_string()));
+        assert_eq!(policy.rules.len(), 2);
+        assert_eq!(policy.default_decision, Decision::Deny);
+
+        // Check first rule
+        let rule1 = &policy.rules[0];
+        assert_eq!(rule1.id, "RULE-001");
+        assert_eq!(rule1.rule_type, RuleType::ToolAllow);
+        assert_eq!(rule1.tool, Some("fs.read".to_string()));
+        assert_eq!(rule1.paths, vec!["/workspace/**"]);
+        assert_eq!(rule1.decision, Decision::Allow);
+
+        // Check second rule
+        let rule2 = &policy.rules[1];
+        assert_eq!(rule2.id, "RULE-002");
+        assert_eq!(rule2.rule_type, RuleType::Budget);
+    }
+
+    #[test]
+    fn test_parse_invalid_yaml() {
+        let result = parse_policy("not: valid: yaml: {{{{");
+        assert!(matches!(result, Err(PolicyError::ParseError(_))));
+    }
+
+    #[test]
+    fn test_parse_missing_required_fields() {
+        let yaml = r#"
+policy:
+  version: "1.0.0"
+"#;
+        let result = parse_policy(yaml);
+        assert!(matches!(result, Err(PolicyError::ParseError(_))));
+    }
+
+    #[test]
+    fn test_parse_and_validate_policy() {
+        let (policy, validated) = parse_and_validate_policy(VALID_POLICY_YAML).unwrap();
+
+        assert_eq!(policy.name, "test-policy");
+        assert_eq!(validated.name, "test-policy");
+        assert_eq!(validated.rule_count, 2);
+    }
+
+    #[test]
+    fn test_compute_policy_hash() {
+        let hash1 = compute_policy_hash(VALID_POLICY_YAML);
+        let hash2 = compute_policy_hash(VALID_POLICY_YAML);
+
+        // Same content should produce same hash
+        assert_eq!(hash1, hash2);
+
+        // Different content should produce different hash
+        let hash3 = compute_policy_hash("different content");
+        assert_ne!(hash1, hash3);
+    }
+
+    #[test]
+    fn test_loaded_policy_from_yaml() {
+        let loaded = LoadedPolicy::from_yaml(VALID_POLICY_YAML).unwrap();
+
+        assert_eq!(loaded.version(), "1.0.0");
+        assert_eq!(loaded.name(), "test-policy");
+        assert_eq!(loaded.rule_count(), 2);
+        assert!(!loaded.content_hash_hex().is_empty());
+        assert_eq!(loaded.content_hash_hex().len(), 64); // 32 bytes = 64 hex chars
+    }
+
+    #[test]
+    fn test_loaded_policy_hash_consistency() {
+        let loaded1 = LoadedPolicy::from_yaml(VALID_POLICY_YAML).unwrap();
+        let loaded2 = LoadedPolicy::from_yaml(VALID_POLICY_YAML).unwrap();
+
+        assert_eq!(loaded1.content_hash, loaded2.content_hash);
+        assert_eq!(loaded1.content_hash_hex(), loaded2.content_hash_hex());
+    }
+
+    #[test]
+    fn test_hex_encode() {
+        assert_eq!(hex_encode(&[0x00]), "00");
+        assert_eq!(hex_encode(&[0xff]), "ff");
+        assert_eq!(hex_encode(&[0xab, 0xcd, 0xef]), "abcdef");
+        assert_eq!(hex_encode(&[]), "");
+    }
+
+    #[test]
+    fn test_parse_minimal_policy() {
+        let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "minimal"
+  rules:
+    - id: "deny-all"
+      type: tool_deny
+      tool: "*"
+      decision: deny
+  default_decision: deny
+"#;
+        let loaded = LoadedPolicy::from_yaml(yaml).unwrap();
+        assert_eq!(loaded.rule_count(), 1);
+    }
+
+    #[test]
+    fn test_parse_complex_policy() {
+        let yaml = r#"
+policy:
+  version: "2.1.0"
+  name: "complex-policy"
+  description: "A more complex policy with multiple rule types"
+  rules:
+    - id: "fs-read-workspace"
+      type: filesystem
+      paths:
+        - "/workspace/**"
+        - "/home/user/projects/**"
+      decision: allow
+      reason: "Allow reading workspace files"
+
+    - id: "network-api"
+      type: network
+      hosts:
+        - "api.github.com"
+        - "api.anthropic.com"
+      ports:
+        - 443
+      decision: allow
+
+    - id: "token-budget"
+      type: budget
+      budget_type: token
+      limit: 500000
+      decision: allow
+
+    - id: "inference-allowed"
+      type: inference
+      decision: allow
+      rationale_code: "INF_ALLOWED"
+
+  default_decision: deny
+"#;
+        let loaded = LoadedPolicy::from_yaml(yaml).unwrap();
+        assert_eq!(loaded.version(), "2.1.0");
+        assert_eq!(loaded.name(), "complex-policy");
+        assert_eq!(loaded.rule_count(), 4);
+    }
+}

--- a/crates/apm2-core/src/policy/schema.rs
+++ b/crates/apm2-core/src/policy/schema.rs
@@ -1,0 +1,506 @@
+//! Policy schema types.
+//!
+//! This module defines the YAML schema for APM2 policy files. Policies are
+//! the core mechanism for controlling agent behavior through default-deny
+//! rules.
+//!
+//! # Schema Overview
+//!
+//! ```yaml
+//! policy:
+//!   version: "1.0.0"
+//!   name: "example-policy"
+//!   description: "Example policy for demonstration"
+//!   rules:
+//!     - id: "RULE-001"
+//!       type: tool_allow
+//!       tool: "fs.read"
+//!       paths:
+//!         - "/workspace/**"
+//!       decision: allow
+//!     - id: "RULE-002"
+//!       type: budget
+//!       budget_type: token
+//!       limit: 100000
+//!       decision: allow
+//!   default_decision: deny
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+use super::error::PolicyError;
+
+/// The root policy document.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PolicyDocument {
+    /// The policy configuration.
+    pub policy: Policy,
+}
+
+/// A policy configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Policy {
+    /// Semantic version of this policy (e.g., "1.0.0").
+    pub version: String,
+
+    /// Human-readable name for this policy.
+    pub name: String,
+
+    /// Optional description of what this policy does.
+    #[serde(default)]
+    pub description: Option<String>,
+
+    /// The list of policy rules, evaluated in order.
+    pub rules: Vec<Rule>,
+
+    /// The default decision when no rules match (should be "deny" for
+    /// default-deny).
+    pub default_decision: Decision,
+}
+
+/// A policy rule.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Rule {
+    /// Unique identifier for this rule within the policy.
+    pub id: String,
+
+    /// The type of rule.
+    #[serde(rename = "type")]
+    pub rule_type: RuleType,
+
+    /// The decision to make when this rule matches.
+    pub decision: Decision,
+
+    /// For tool rules: the tool name pattern to match.
+    #[serde(default)]
+    pub tool: Option<String>,
+
+    /// For tool rules: path patterns to match.
+    #[serde(default)]
+    pub paths: Vec<String>,
+
+    /// For tool rules: command patterns to match.
+    #[serde(default)]
+    pub commands: Vec<String>,
+
+    /// For budget rules: the type of budget.
+    #[serde(default)]
+    pub budget_type: Option<BudgetType>,
+
+    /// For budget rules: the budget limit.
+    #[serde(default)]
+    pub limit: Option<u64>,
+
+    /// For network rules: allowed hosts.
+    #[serde(default)]
+    pub hosts: Vec<String>,
+
+    /// For network rules: allowed ports.
+    #[serde(default)]
+    pub ports: Vec<u16>,
+
+    /// Optional condition expression for rule activation.
+    #[serde(default)]
+    pub condition: Option<String>,
+
+    /// Optional rationale code to include in decision events.
+    #[serde(default)]
+    pub rationale_code: Option<String>,
+
+    /// Optional human-readable reason for this rule.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// The type of a policy rule.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum RuleType {
+    /// Rule that allows or denies a specific tool.
+    ToolAllow,
+    /// Rule that allows or denies specific tool patterns.
+    ToolDeny,
+    /// Rule that sets budget limits.
+    Budget,
+    /// Rule for network access control.
+    Network,
+    /// Rule for filesystem access control.
+    Filesystem,
+    /// Rule for secrets access control.
+    Secrets,
+    /// Rule for inference/model access control.
+    Inference,
+}
+
+impl RuleType {
+    /// Parses a rule type from a string.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PolicyError::InvalidRuleType` if the string is not a
+    /// recognized type.
+    pub fn parse(s: &str) -> Result<Self, PolicyError> {
+        match s.to_lowercase().as_str() {
+            "tool_allow" => Ok(Self::ToolAllow),
+            "tool_deny" => Ok(Self::ToolDeny),
+            "budget" => Ok(Self::Budget),
+            "network" => Ok(Self::Network),
+            "filesystem" => Ok(Self::Filesystem),
+            "secrets" => Ok(Self::Secrets),
+            "inference" => Ok(Self::Inference),
+            _ => Err(PolicyError::InvalidRuleType {
+                value: s.to_string(),
+            }),
+        }
+    }
+
+    /// Returns the string representation of this rule type.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::ToolAllow => "tool_allow",
+            Self::ToolDeny => "tool_deny",
+            Self::Budget => "budget",
+            Self::Network => "network",
+            Self::Filesystem => "filesystem",
+            Self::Secrets => "secrets",
+            Self::Inference => "inference",
+        }
+    }
+}
+
+impl std::fmt::Display for RuleType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// A policy decision.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum Decision {
+    /// Allow the action.
+    Allow,
+    /// Deny the action (default for default-deny policies).
+    #[default]
+    Deny,
+}
+
+impl Decision {
+    /// Parses a decision from a string.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PolicyError::InvalidDecision` if the string is not "allow" or
+    /// "deny".
+    pub fn parse(s: &str) -> Result<Self, PolicyError> {
+        match s.to_lowercase().as_str() {
+            "allow" => Ok(Self::Allow),
+            "deny" => Ok(Self::Deny),
+            _ => Err(PolicyError::InvalidDecision {
+                value: s.to_string(),
+            }),
+        }
+    }
+
+    /// Returns the string representation of this decision.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Deny => "deny",
+        }
+    }
+
+    /// Returns true if this is an allow decision.
+    #[must_use]
+    pub const fn is_allow(&self) -> bool {
+        matches!(self, Self::Allow)
+    }
+
+    /// Returns true if this is a deny decision.
+    #[must_use]
+    pub const fn is_deny(&self) -> bool {
+        matches!(self, Self::Deny)
+    }
+}
+
+impl std::fmt::Display for Decision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// The type of budget being limited.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum BudgetType {
+    /// Token budget for inference calls.
+    Token,
+    /// Time budget in milliseconds.
+    Time,
+    /// Budget for number of tool calls.
+    ToolCalls,
+    /// Budget for number of inference calls.
+    InferenceCalls,
+    /// Budget for filesystem operations.
+    FilesystemOps,
+    /// Budget for network operations.
+    NetworkOps,
+}
+
+impl BudgetType {
+    /// Parses a budget type from a string.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PolicyError::InvalidBudgetType` if the string is not a
+    /// recognized type.
+    pub fn parse(s: &str) -> Result<Self, PolicyError> {
+        match s.to_lowercase().as_str() {
+            "token" => Ok(Self::Token),
+            "time" => Ok(Self::Time),
+            "tool_calls" => Ok(Self::ToolCalls),
+            "inference_calls" => Ok(Self::InferenceCalls),
+            "filesystem_ops" => Ok(Self::FilesystemOps),
+            "network_ops" => Ok(Self::NetworkOps),
+            _ => Err(PolicyError::InvalidBudgetType {
+                value: s.to_string(),
+            }),
+        }
+    }
+
+    /// Returns the string representation of this budget type.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Token => "token",
+            Self::Time => "time",
+            Self::ToolCalls => "tool_calls",
+            Self::InferenceCalls => "inference_calls",
+            Self::FilesystemOps => "filesystem_ops",
+            Self::NetworkOps => "network_ops",
+        }
+    }
+}
+
+impl std::fmt::Display for BudgetType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// A parsed and validated policy version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PolicyVersion {
+    /// Major version number.
+    pub major: u32,
+    /// Minor version number.
+    pub minor: u32,
+    /// Patch version number.
+    pub patch: u32,
+}
+
+impl PolicyVersion {
+    /// Creates a new policy version.
+    #[must_use]
+    pub const fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// Parses a version string in the format "MAJOR.MINOR.PATCH".
+    ///
+    /// # Errors
+    ///
+    /// Returns `PolicyError::InvalidVersion` if the string is not a valid
+    /// semver version.
+    pub fn parse(s: &str) -> Result<Self, PolicyError> {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() != 3 {
+            return Err(PolicyError::InvalidVersion {
+                version: s.to_string(),
+            });
+        }
+
+        let parse_part = |part: &str| -> Result<u32, PolicyError> {
+            part.parse::<u32>()
+                .map_err(|_| PolicyError::InvalidVersion {
+                    version: s.to_string(),
+                })
+        };
+
+        Ok(Self {
+            major: parse_part(parts[0])?,
+            minor: parse_part(parts[1])?,
+            patch: parse_part(parts[2])?,
+        })
+    }
+}
+
+impl std::fmt::Display for PolicyVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rule_type_parse() {
+        assert_eq!(RuleType::parse("tool_allow").unwrap(), RuleType::ToolAllow);
+        assert_eq!(RuleType::parse("TOOL_ALLOW").unwrap(), RuleType::ToolAllow);
+        assert_eq!(RuleType::parse("tool_deny").unwrap(), RuleType::ToolDeny);
+        assert_eq!(RuleType::parse("budget").unwrap(), RuleType::Budget);
+        assert_eq!(RuleType::parse("network").unwrap(), RuleType::Network);
+        assert_eq!(RuleType::parse("filesystem").unwrap(), RuleType::Filesystem);
+        assert_eq!(RuleType::parse("secrets").unwrap(), RuleType::Secrets);
+        assert_eq!(RuleType::parse("inference").unwrap(), RuleType::Inference);
+    }
+
+    #[test]
+    fn test_rule_type_parse_invalid() {
+        let result = RuleType::parse("unknown");
+        assert!(matches!(result, Err(PolicyError::InvalidRuleType { .. })));
+    }
+
+    #[test]
+    fn test_rule_type_as_str() {
+        assert_eq!(RuleType::ToolAllow.as_str(), "tool_allow");
+        assert_eq!(RuleType::ToolDeny.as_str(), "tool_deny");
+        assert_eq!(RuleType::Budget.as_str(), "budget");
+        assert_eq!(RuleType::Network.as_str(), "network");
+        assert_eq!(RuleType::Filesystem.as_str(), "filesystem");
+        assert_eq!(RuleType::Secrets.as_str(), "secrets");
+        assert_eq!(RuleType::Inference.as_str(), "inference");
+    }
+
+    #[test]
+    fn test_decision_parse() {
+        assert_eq!(Decision::parse("allow").unwrap(), Decision::Allow);
+        assert_eq!(Decision::parse("ALLOW").unwrap(), Decision::Allow);
+        assert_eq!(Decision::parse("deny").unwrap(), Decision::Deny);
+        assert_eq!(Decision::parse("DENY").unwrap(), Decision::Deny);
+    }
+
+    #[test]
+    fn test_decision_parse_invalid() {
+        let result = Decision::parse("maybe");
+        assert!(matches!(result, Err(PolicyError::InvalidDecision { .. })));
+    }
+
+    #[test]
+    fn test_decision_as_str() {
+        assert_eq!(Decision::Allow.as_str(), "allow");
+        assert_eq!(Decision::Deny.as_str(), "deny");
+    }
+
+    #[test]
+    fn test_decision_is_allow_deny() {
+        assert!(Decision::Allow.is_allow());
+        assert!(!Decision::Allow.is_deny());
+        assert!(!Decision::Deny.is_allow());
+        assert!(Decision::Deny.is_deny());
+    }
+
+    #[test]
+    fn test_decision_default() {
+        // Default-deny: the default should be Deny
+        assert_eq!(Decision::default(), Decision::Deny);
+    }
+
+    #[test]
+    fn test_budget_type_parse() {
+        assert_eq!(BudgetType::parse("token").unwrap(), BudgetType::Token);
+        assert_eq!(BudgetType::parse("TOKEN").unwrap(), BudgetType::Token);
+        assert_eq!(BudgetType::parse("time").unwrap(), BudgetType::Time);
+        assert_eq!(
+            BudgetType::parse("tool_calls").unwrap(),
+            BudgetType::ToolCalls
+        );
+        assert_eq!(
+            BudgetType::parse("inference_calls").unwrap(),
+            BudgetType::InferenceCalls
+        );
+        assert_eq!(
+            BudgetType::parse("filesystem_ops").unwrap(),
+            BudgetType::FilesystemOps
+        );
+        assert_eq!(
+            BudgetType::parse("network_ops").unwrap(),
+            BudgetType::NetworkOps
+        );
+    }
+
+    #[test]
+    fn test_budget_type_parse_invalid() {
+        let result = BudgetType::parse("unknown");
+        assert!(matches!(result, Err(PolicyError::InvalidBudgetType { .. })));
+    }
+
+    #[test]
+    fn test_budget_type_as_str() {
+        assert_eq!(BudgetType::Token.as_str(), "token");
+        assert_eq!(BudgetType::Time.as_str(), "time");
+        assert_eq!(BudgetType::ToolCalls.as_str(), "tool_calls");
+        assert_eq!(BudgetType::InferenceCalls.as_str(), "inference_calls");
+        assert_eq!(BudgetType::FilesystemOps.as_str(), "filesystem_ops");
+        assert_eq!(BudgetType::NetworkOps.as_str(), "network_ops");
+    }
+
+    #[test]
+    fn test_policy_version_parse() {
+        let v = PolicyVersion::parse("1.0.0").unwrap();
+        assert_eq!(v.major, 1);
+        assert_eq!(v.minor, 0);
+        assert_eq!(v.patch, 0);
+
+        let v = PolicyVersion::parse("2.10.3").unwrap();
+        assert_eq!(v.major, 2);
+        assert_eq!(v.minor, 10);
+        assert_eq!(v.patch, 3);
+    }
+
+    #[test]
+    fn test_policy_version_parse_invalid() {
+        // Missing parts
+        assert!(PolicyVersion::parse("1.0").is_err());
+        assert!(PolicyVersion::parse("1").is_err());
+        assert!(PolicyVersion::parse("").is_err());
+
+        // Non-numeric parts
+        assert!(PolicyVersion::parse("a.b.c").is_err());
+        assert!(PolicyVersion::parse("1.0.a").is_err());
+
+        // Extra parts
+        assert!(PolicyVersion::parse("1.0.0.0").is_err());
+    }
+
+    #[test]
+    fn test_policy_version_display() {
+        let v = PolicyVersion::new(1, 2, 3);
+        assert_eq!(v.to_string(), "1.2.3");
+    }
+
+    #[test]
+    fn test_policy_version_ordering() {
+        let v1 = PolicyVersion::new(1, 0, 0);
+        let v2 = PolicyVersion::new(1, 1, 0);
+        let v3 = PolicyVersion::new(2, 0, 0);
+
+        assert!(v1 < v2);
+        assert!(v2 < v3);
+        assert!(v1 < v3);
+    }
+}

--- a/crates/apm2-core/src/policy/tests.rs
+++ b/crates/apm2-core/src/policy/tests.rs
@@ -1,0 +1,619 @@
+//! Integration tests for the policy module.
+
+use super::*;
+
+/// Example policy for testing various rule types.
+const COMPREHENSIVE_POLICY: &str = r#"
+policy:
+  version: "1.0.0"
+  name: "comprehensive-test-policy"
+  description: "Tests all rule types and edge cases"
+  rules:
+    # Tool rules
+    - id: "allow-fs-read"
+      type: tool_allow
+      tool: "fs.read"
+      paths:
+        - "/workspace/**"
+        - "/home/user/allowed/**"
+      decision: allow
+      reason: "Allow reading workspace files"
+      rationale_code: "FS_READ_ALLOWED"
+
+    - id: "deny-fs-write-sensitive"
+      type: tool_deny
+      tool: "fs.write"
+      paths:
+        - "/etc/**"
+        - "/var/**"
+      decision: deny
+      reason: "Deny writing to system directories"
+
+    # Budget rules
+    - id: "token-budget"
+      type: budget
+      budget_type: token
+      limit: 100000
+      decision: allow
+
+    - id: "time-budget"
+      type: budget
+      budget_type: time
+      limit: 3600000
+      decision: allow
+      reason: "1 hour time limit"
+
+    - id: "tool-call-budget"
+      type: budget
+      budget_type: tool_calls
+      limit: 1000
+      decision: allow
+
+    # Network rules
+    - id: "allow-github-api"
+      type: network
+      hosts:
+        - "api.github.com"
+        - "raw.githubusercontent.com"
+      ports:
+        - 443
+      decision: allow
+
+    - id: "allow-inference-api"
+      type: network
+      hosts:
+        - "api.anthropic.com"
+        - "api.openai.com"
+      ports:
+        - 443
+      decision: allow
+
+    # Filesystem rules
+    - id: "allow-workspace-fs"
+      type: filesystem
+      paths:
+        - "/workspace/**"
+      decision: allow
+
+    # Secrets rules
+    - id: "allow-secrets"
+      type: secrets
+      decision: allow
+      condition: "lease.scope.includes_secrets"
+
+    # Inference rules
+    - id: "allow-inference"
+      type: inference
+      decision: allow
+
+  default_decision: deny
+"#;
+
+#[test]
+fn test_parse_comprehensive_policy() {
+    let loaded = LoadedPolicy::from_yaml(COMPREHENSIVE_POLICY).unwrap();
+
+    assert_eq!(loaded.version(), "1.0.0");
+    assert_eq!(loaded.name(), "comprehensive-test-policy");
+    assert_eq!(loaded.rule_count(), 10);
+}
+
+#[test]
+fn test_policy_hash_is_deterministic() {
+    let loaded1 = LoadedPolicy::from_yaml(COMPREHENSIVE_POLICY).unwrap();
+    let loaded2 = LoadedPolicy::from_yaml(COMPREHENSIVE_POLICY).unwrap();
+
+    // Hash should be identical for identical content
+    assert_eq!(loaded1.content_hash, loaded2.content_hash);
+    assert_eq!(loaded1.content_hash_hex(), loaded2.content_hash_hex());
+}
+
+#[test]
+fn test_policy_hash_differs_for_different_content() {
+    let yaml1 = r#"
+policy:
+  version: "1.0.0"
+  name: "policy-1"
+  rules:
+    - id: "rule-1"
+      type: tool_allow
+      tool: "fs.read"
+      decision: allow
+  default_decision: deny
+"#;
+
+    let yaml2 = r#"
+policy:
+  version: "1.0.0"
+  name: "policy-2"
+  rules:
+    - id: "rule-1"
+      type: tool_allow
+      tool: "fs.write"
+      decision: allow
+  default_decision: deny
+"#;
+
+    let loaded1 = LoadedPolicy::from_yaml(yaml1).unwrap();
+    let loaded2 = LoadedPolicy::from_yaml(yaml2).unwrap();
+
+    assert_ne!(loaded1.content_hash, loaded2.content_hash);
+}
+
+use crate::events::policy_event;
+
+#[test]
+fn test_policy_loaded_event_contains_hash() {
+    let loaded = LoadedPolicy::from_yaml(COMPREHENSIVE_POLICY).unwrap();
+    let event = create_policy_loaded_event(&loaded);
+
+    match event.event {
+        Some(policy_event::Event::Loaded(loaded_event)) => {
+            assert_eq!(loaded_event.policy_hash.len(), 32);
+            assert_eq!(loaded_event.policy_hash, loaded.content_hash.to_vec());
+            assert_eq!(loaded_event.policy_version, "1.0.0");
+            assert_eq!(loaded_event.rule_count, 10);
+        },
+        _ => panic!("Expected PolicyLoaded event"),
+    }
+}
+
+#[test]
+fn test_validate_rejects_empty_rules() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "empty-rules"
+  rules: []
+  default_decision: deny
+"#;
+
+    let result = LoadedPolicy::from_yaml(yaml);
+    assert!(matches!(result, Err(PolicyError::EmptyPolicy)));
+}
+
+#[test]
+fn test_validate_rejects_duplicate_rule_ids() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "duplicate-ids"
+  rules:
+    - id: "same-id"
+      type: tool_allow
+      tool: "fs.read"
+      decision: allow
+    - id: "same-id"
+      type: tool_deny
+      tool: "fs.write"
+      decision: deny
+  default_decision: deny
+"#;
+
+    let result = LoadedPolicy::from_yaml(yaml);
+    assert!(matches!(
+        result,
+        Err(PolicyError::DuplicateRuleId { rule_id }) if rule_id == "same-id"
+    ));
+}
+
+#[test]
+fn test_validate_rejects_invalid_version() {
+    let yaml = r#"
+policy:
+  version: "invalid"
+  name: "invalid-version"
+  rules:
+    - id: "rule-1"
+      type: tool_allow
+      tool: "fs.read"
+      decision: allow
+  default_decision: deny
+"#;
+
+    let result = LoadedPolicy::from_yaml(yaml);
+    assert!(matches!(result, Err(PolicyError::InvalidVersion { .. })));
+}
+
+#[test]
+fn test_validate_rejects_budget_without_type() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "missing-budget-type"
+  rules:
+    - id: "budget-rule"
+      type: budget
+      limit: 1000
+      decision: allow
+  default_decision: deny
+"#;
+
+    let result = LoadedPolicy::from_yaml(yaml);
+    assert!(matches!(result, Err(PolicyError::ValidationError { .. })));
+}
+
+#[test]
+fn test_validate_rejects_budget_without_limit() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "missing-budget-limit"
+  rules:
+    - id: "budget-rule"
+      type: budget
+      budget_type: token
+      decision: allow
+  default_decision: deny
+"#;
+
+    let result = LoadedPolicy::from_yaml(yaml);
+    assert!(matches!(result, Err(PolicyError::ValidationError { .. })));
+}
+
+#[test]
+fn test_validate_rejects_network_without_hosts_or_ports() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "missing-network-config"
+  rules:
+    - id: "network-rule"
+      type: network
+      decision: allow
+  default_decision: deny
+"#;
+
+    let result = LoadedPolicy::from_yaml(yaml);
+    assert!(matches!(result, Err(PolicyError::ValidationError { .. })));
+}
+
+#[test]
+fn test_validate_rejects_filesystem_without_paths() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "missing-fs-paths"
+  rules:
+    - id: "fs-rule"
+      type: filesystem
+      decision: allow
+  default_decision: deny
+"#;
+
+    let result = LoadedPolicy::from_yaml(yaml);
+    assert!(matches!(result, Err(PolicyError::ValidationError { .. })));
+}
+
+#[test]
+fn test_validate_rejects_tool_without_specifier() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "missing-tool-specifier"
+  rules:
+    - id: "tool-rule"
+      type: tool_allow
+      decision: allow
+  default_decision: deny
+"#;
+
+    let result = LoadedPolicy::from_yaml(yaml);
+    assert!(matches!(result, Err(PolicyError::ValidationError { .. })));
+}
+
+#[test]
+fn test_policy_with_default_allow_parses() {
+    // Note: This is valid YAML, but security practice dictates default_decision
+    // should be deny. The parser allows it for flexibility.
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "default-allow"
+  rules:
+    - id: "deny-dangerous"
+      type: tool_deny
+      tool: "dangerous_tool"
+      decision: deny
+  default_decision: allow
+"#;
+
+    let loaded = LoadedPolicy::from_yaml(yaml).unwrap();
+    assert_eq!(loaded.policy.default_decision, Decision::Allow);
+}
+
+#[test]
+fn test_all_budget_types_parse() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "all-budgets"
+  rules:
+    - id: "token"
+      type: budget
+      budget_type: token
+      limit: 100000
+      decision: allow
+    - id: "time"
+      type: budget
+      budget_type: time
+      limit: 3600000
+      decision: allow
+    - id: "tool-calls"
+      type: budget
+      budget_type: tool_calls
+      limit: 1000
+      decision: allow
+    - id: "inference-calls"
+      type: budget
+      budget_type: inference_calls
+      limit: 100
+      decision: allow
+    - id: "filesystem-ops"
+      type: budget
+      budget_type: filesystem_ops
+      limit: 5000
+      decision: allow
+    - id: "network-ops"
+      type: budget
+      budget_type: network_ops
+      limit: 500
+      decision: allow
+  default_decision: deny
+"#;
+
+    let loaded = LoadedPolicy::from_yaml(yaml).unwrap();
+    assert_eq!(loaded.rule_count(), 6);
+
+    // Verify each budget type
+    let rules = &loaded.policy.rules;
+    assert_eq!(rules[0].budget_type, Some(BudgetType::Token));
+    assert_eq!(rules[1].budget_type, Some(BudgetType::Time));
+    assert_eq!(rules[2].budget_type, Some(BudgetType::ToolCalls));
+    assert_eq!(rules[3].budget_type, Some(BudgetType::InferenceCalls));
+    assert_eq!(rules[4].budget_type, Some(BudgetType::FilesystemOps));
+    assert_eq!(rules[5].budget_type, Some(BudgetType::NetworkOps));
+}
+
+#[test]
+fn test_all_rule_types_parse() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "all-rule-types"
+  rules:
+    - id: "tool-allow"
+      type: tool_allow
+      tool: "fs.read"
+      decision: allow
+    - id: "tool-deny"
+      type: tool_deny
+      tool: "dangerous"
+      decision: deny
+    - id: "budget"
+      type: budget
+      budget_type: token
+      limit: 1000
+      decision: allow
+    - id: "network"
+      type: network
+      hosts:
+        - "example.com"
+      decision: allow
+    - id: "filesystem"
+      type: filesystem
+      paths:
+        - "/tmp/**"
+      decision: allow
+    - id: "secrets"
+      type: secrets
+      decision: deny
+    - id: "inference"
+      type: inference
+      decision: allow
+  default_decision: deny
+"#;
+
+    let loaded = LoadedPolicy::from_yaml(yaml).unwrap();
+    assert_eq!(loaded.rule_count(), 7);
+
+    let rules = &loaded.policy.rules;
+    assert_eq!(rules[0].rule_type, RuleType::ToolAllow);
+    assert_eq!(rules[1].rule_type, RuleType::ToolDeny);
+    assert_eq!(rules[2].rule_type, RuleType::Budget);
+    assert_eq!(rules[3].rule_type, RuleType::Network);
+    assert_eq!(rules[4].rule_type, RuleType::Filesystem);
+    assert_eq!(rules[5].rule_type, RuleType::Secrets);
+    assert_eq!(rules[6].rule_type, RuleType::Inference);
+}
+
+#[test]
+fn test_glob_patterns_in_paths() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "glob-patterns"
+  rules:
+    - id: "various-patterns"
+      type: filesystem
+      paths:
+        - "/workspace/**"
+        - "/home/*/projects/**"
+        - "*.rs"
+        - "src/[abc]*.rs"
+        - "{foo,bar}/**"
+      decision: allow
+  default_decision: deny
+"#;
+
+    let loaded = LoadedPolicy::from_yaml(yaml).unwrap();
+    let paths = &loaded.policy.rules[0].paths;
+
+    assert_eq!(paths.len(), 5);
+    assert!(paths.contains(&"/workspace/**".to_string()));
+    assert!(paths.contains(&"/home/*/projects/**".to_string()));
+    assert!(paths.contains(&"*.rs".to_string()));
+    assert!(paths.contains(&"src/[abc]*.rs".to_string()));
+    assert!(paths.contains(&"{foo,bar}/**".to_string()));
+}
+
+#[test]
+fn test_policy_with_conditions() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "conditional-policy"
+  rules:
+    - id: "conditional-secrets"
+      type: secrets
+      decision: allow
+      condition: "lease.scope.includes_secrets && session.actor_id.starts_with('trusted-')"
+  default_decision: deny
+"#;
+
+    let loaded = LoadedPolicy::from_yaml(yaml).unwrap();
+    let condition = &loaded.policy.rules[0].condition;
+
+    assert!(condition.is_some());
+    assert!(condition.as_ref().unwrap().contains("lease.scope"));
+}
+
+#[test]
+fn test_policy_with_rationale_codes() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "rationale-codes"
+  rules:
+    - id: "documented-rule"
+      type: tool_allow
+      tool: "fs.read"
+      decision: allow
+      rationale_code: "SEC_001_FS_READ_ALLOWED"
+      reason: "Allow filesystem read operations for workspace access"
+  default_decision: deny
+"#;
+
+    let loaded = LoadedPolicy::from_yaml(yaml).unwrap();
+    let rule = &loaded.policy.rules[0];
+
+    assert_eq!(
+        rule.rationale_code,
+        Some("SEC_001_FS_READ_ALLOWED".to_string())
+    );
+    assert!(rule.reason.is_some());
+}
+
+#[test]
+fn test_minimal_valid_policy() {
+    // The absolute minimum valid policy
+    let yaml = r#"
+policy:
+  version: "0.0.1"
+  name: "x"
+  rules:
+    - id: "r"
+      type: tool_allow
+      tool: "*"
+      decision: deny
+  default_decision: deny
+"#;
+
+    let loaded = LoadedPolicy::from_yaml(yaml).unwrap();
+    assert_eq!(loaded.version(), "0.0.1");
+    assert_eq!(loaded.name(), "x");
+    assert_eq!(loaded.rule_count(), 1);
+}
+
+#[test]
+fn test_network_rule_with_ports_only() {
+    let yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "ports-only"
+  rules:
+    - id: "https-only"
+      type: network
+      ports:
+        - 443
+        - 8443
+      decision: allow
+  default_decision: deny
+"#;
+
+    let loaded = LoadedPolicy::from_yaml(yaml).unwrap();
+    let ports = &loaded.policy.rules[0].ports;
+
+    assert_eq!(ports.len(), 2);
+    assert!(ports.contains(&443));
+    assert!(ports.contains(&8443));
+}
+
+#[test]
+fn test_policy_version_ordering() {
+    assert!(PolicyVersion::new(1, 0, 0) < PolicyVersion::new(1, 0, 1));
+    assert!(PolicyVersion::new(1, 0, 0) < PolicyVersion::new(1, 1, 0));
+    assert!(PolicyVersion::new(1, 0, 0) < PolicyVersion::new(2, 0, 0));
+    assert!(PolicyVersion::new(1, 9, 9) < PolicyVersion::new(2, 0, 0));
+}
+
+#[test]
+fn test_compute_policy_hash_direct() {
+    let content = "test content for hashing";
+    let hash = compute_policy_hash(content);
+
+    assert_eq!(hash.len(), 32);
+
+    // Should be deterministic
+    let hash2 = compute_policy_hash(content);
+    assert_eq!(hash, hash2);
+}
+
+#[test]
+fn test_invalid_yaml_produces_parse_error() {
+    let invalid_yamls = [
+        "not valid yaml at all {{{",
+        "policy:\n  version: [1, 2, 3]", // version should be string
+        "policy:\n  rules: 'not a list'",
+        "",
+        "   ",
+    ];
+
+    for yaml in invalid_yamls {
+        let result = LoadedPolicy::from_yaml(yaml);
+        assert!(result.is_err(), "Expected error for invalid yaml: {yaml:?}");
+    }
+}
+
+#[test]
+fn test_policy_default_decision_parsing() {
+    let allow_yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "allow-default"
+  rules:
+    - id: "r"
+      type: tool_deny
+      tool: "bad"
+      decision: deny
+  default_decision: allow
+"#;
+
+    let deny_yaml = r#"
+policy:
+  version: "1.0.0"
+  name: "deny-default"
+  rules:
+    - id: "r"
+      type: tool_allow
+      tool: "good"
+      decision: allow
+  default_decision: deny
+"#;
+
+    let allow_loaded = LoadedPolicy::from_yaml(allow_yaml).unwrap();
+    let deny_loaded = LoadedPolicy::from_yaml(deny_yaml).unwrap();
+
+    assert!(allow_loaded.policy.default_decision.is_allow());
+    assert!(deny_loaded.policy.default_decision.is_deny());
+}

--- a/crates/apm2-core/src/policy/validator.rs
+++ b/crates/apm2-core/src/policy/validator.rs
@@ -1,0 +1,547 @@
+//! Policy validation.
+//!
+//! This module provides validation for policy documents to ensure they are
+//! well-formed before use.
+
+use std::collections::HashSet;
+
+use super::error::PolicyError;
+use super::schema::{Policy, PolicyVersion, Rule, RuleType};
+
+/// Validates a policy document.
+///
+/// # Errors
+///
+/// Returns `PolicyError` if the policy is invalid.
+pub fn validate_policy(policy: &Policy) -> Result<ValidatedPolicy, PolicyError> {
+    // Validate version format
+    let version = PolicyVersion::parse(&policy.version)?;
+
+    // Validate name is non-empty
+    if policy.name.trim().is_empty() {
+        return Err(PolicyError::missing_field("name"));
+    }
+
+    // Validate rules
+    if policy.rules.is_empty() {
+        return Err(PolicyError::EmptyPolicy);
+    }
+
+    // Check for duplicate rule IDs
+    let mut seen_ids = HashSet::new();
+    for rule in &policy.rules {
+        if !seen_ids.insert(&rule.id) {
+            return Err(PolicyError::duplicate_rule_id(&rule.id));
+        }
+        validate_rule(rule)?;
+    }
+
+    Ok(ValidatedPolicy {
+        version,
+        name: policy.name.clone(),
+        description: policy.description.clone(),
+        rule_count: policy.rules.len(),
+    })
+}
+
+/// Validates a single rule.
+fn validate_rule(rule: &Rule) -> Result<(), PolicyError> {
+    // Validate rule ID is non-empty
+    if rule.id.trim().is_empty() {
+        return Err(PolicyError::missing_field("rule.id"));
+    }
+
+    // Validate rule-type-specific requirements
+    match rule.rule_type {
+        RuleType::ToolAllow | RuleType::ToolDeny => {
+            validate_tool_rule(rule)?;
+        },
+        RuleType::Budget => {
+            validate_budget_rule(rule)?;
+        },
+        RuleType::Network => {
+            validate_network_rule(rule)?;
+        },
+        RuleType::Filesystem => {
+            validate_filesystem_rule(rule)?;
+        },
+        // Secrets and Inference rules have no additional requirements
+        RuleType::Secrets | RuleType::Inference => {},
+    }
+
+    // Validate path patterns if present
+    for path in &rule.paths {
+        validate_glob_pattern(&rule.id, path)?;
+    }
+
+    // Validate command patterns if present
+    for cmd in &rule.commands {
+        validate_glob_pattern(&rule.id, cmd)?;
+    }
+
+    Ok(())
+}
+
+/// Validates a tool rule has required fields.
+fn validate_tool_rule(rule: &Rule) -> Result<(), PolicyError> {
+    // Tool rules should have a tool name or path patterns
+    if rule.tool.is_none() && rule.paths.is_empty() && rule.commands.is_empty() {
+        return Err(PolicyError::validation(format!(
+            "tool rule '{}' must specify 'tool', 'paths', or 'commands'",
+            rule.id
+        )));
+    }
+
+    // If tool is specified, it must be non-empty
+    if let Some(ref tool) = rule.tool {
+        if tool.trim().is_empty() {
+            return Err(PolicyError::validation(format!(
+                "tool rule '{}' has empty 'tool' field",
+                rule.id
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates a budget rule has required fields.
+fn validate_budget_rule(rule: &Rule) -> Result<(), PolicyError> {
+    // Budget rules must have budget_type and limit
+    if rule.budget_type.is_none() {
+        return Err(PolicyError::validation(format!(
+            "budget rule '{}' must specify 'budget_type'",
+            rule.id
+        )));
+    }
+
+    if rule.limit.is_none() {
+        return Err(PolicyError::validation(format!(
+            "budget rule '{}' must specify 'limit'",
+            rule.id
+        )));
+    }
+
+    // Limit must be positive for meaningful budgets
+    if let Some(limit) = rule.limit {
+        if limit == 0 {
+            return Err(PolicyError::validation(format!(
+                "budget rule '{}' has zero limit; use a deny rule instead",
+                rule.id
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates a network rule has required fields.
+fn validate_network_rule(rule: &Rule) -> Result<(), PolicyError> {
+    // Network rules should have hosts or ports specified
+    if rule.hosts.is_empty() && rule.ports.is_empty() {
+        return Err(PolicyError::validation(format!(
+            "network rule '{}' must specify 'hosts' or 'ports'",
+            rule.id
+        )));
+    }
+
+    // Validate hosts are non-empty strings
+    for host in &rule.hosts {
+        if host.trim().is_empty() {
+            return Err(PolicyError::validation(format!(
+                "network rule '{}' has empty host",
+                rule.id
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates a filesystem rule has required fields.
+fn validate_filesystem_rule(rule: &Rule) -> Result<(), PolicyError> {
+    // Filesystem rules should have paths specified
+    if rule.paths.is_empty() {
+        return Err(PolicyError::validation(format!(
+            "filesystem rule '{}' must specify 'paths'",
+            rule.id
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validates a glob pattern is syntactically correct.
+fn validate_glob_pattern(rule_id: &str, pattern: &str) -> Result<(), PolicyError> {
+    // Empty patterns are invalid
+    if pattern.is_empty() {
+        return Err(PolicyError::InvalidGlobPattern {
+            rule_id: rule_id.to_string(),
+            pattern: pattern.to_string(),
+            reason: "pattern cannot be empty".to_string(),
+        });
+    }
+
+    // Check for unbalanced brackets
+    let mut bracket_depth = 0i32;
+    let mut brace_depth = 0i32;
+    let mut in_escape = false;
+
+    for ch in pattern.chars() {
+        if in_escape {
+            in_escape = false;
+            continue;
+        }
+
+        match ch {
+            '\\' => in_escape = true,
+            '[' => bracket_depth += 1,
+            ']' => {
+                bracket_depth -= 1;
+                if bracket_depth < 0 {
+                    return Err(PolicyError::InvalidGlobPattern {
+                        rule_id: rule_id.to_string(),
+                        pattern: pattern.to_string(),
+                        reason: "unbalanced brackets".to_string(),
+                    });
+                }
+            },
+            '{' => brace_depth += 1,
+            '}' => {
+                brace_depth -= 1;
+                if brace_depth < 0 {
+                    return Err(PolicyError::InvalidGlobPattern {
+                        rule_id: rule_id.to_string(),
+                        pattern: pattern.to_string(),
+                        reason: "unbalanced braces".to_string(),
+                    });
+                }
+            },
+            _ => {},
+        }
+    }
+
+    if bracket_depth != 0 {
+        return Err(PolicyError::InvalidGlobPattern {
+            rule_id: rule_id.to_string(),
+            pattern: pattern.to_string(),
+            reason: "unbalanced brackets".to_string(),
+        });
+    }
+
+    if brace_depth != 0 {
+        return Err(PolicyError::InvalidGlobPattern {
+            rule_id: rule_id.to_string(),
+            pattern: pattern.to_string(),
+            reason: "unbalanced braces".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+/// A validated policy summary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedPolicy {
+    /// The parsed policy version.
+    pub version: PolicyVersion,
+    /// The policy name.
+    pub name: String,
+    /// Optional description.
+    pub description: Option<String>,
+    /// Number of rules in the policy.
+    pub rule_count: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::schema::{BudgetType, Decision};
+
+    fn make_policy(rules: Vec<Rule>) -> Policy {
+        Policy {
+            version: "1.0.0".to_string(),
+            name: "test-policy".to_string(),
+            description: None,
+            rules,
+            default_decision: Decision::Deny,
+        }
+    }
+
+    fn make_tool_rule(id: &str, tool: Option<&str>) -> Rule {
+        Rule {
+            id: id.to_string(),
+            rule_type: RuleType::ToolAllow,
+            decision: Decision::Allow,
+            tool: tool.map(String::from),
+            paths: vec![],
+            commands: vec![],
+            budget_type: None,
+            limit: None,
+            hosts: vec![],
+            ports: vec![],
+            condition: None,
+            rationale_code: None,
+            reason: None,
+        }
+    }
+
+    fn make_budget_rule(id: &str, budget_type: Option<BudgetType>, limit: Option<u64>) -> Rule {
+        Rule {
+            id: id.to_string(),
+            rule_type: RuleType::Budget,
+            decision: Decision::Allow,
+            tool: None,
+            paths: vec![],
+            commands: vec![],
+            budget_type,
+            limit,
+            hosts: vec![],
+            ports: vec![],
+            condition: None,
+            rationale_code: None,
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn test_validate_valid_policy() {
+        let policy = make_policy(vec![make_tool_rule("RULE-001", Some("fs.read"))]);
+
+        let result = validate_policy(&policy).unwrap();
+        assert_eq!(result.version, PolicyVersion::new(1, 0, 0));
+        assert_eq!(result.name, "test-policy");
+        assert_eq!(result.rule_count, 1);
+    }
+
+    #[test]
+    fn test_validate_empty_policy_fails() {
+        let policy = make_policy(vec![]);
+        let result = validate_policy(&policy);
+        assert!(matches!(result, Err(PolicyError::EmptyPolicy)));
+    }
+
+    #[test]
+    fn test_validate_duplicate_rule_id_fails() {
+        let policy = make_policy(vec![
+            make_tool_rule("RULE-001", Some("fs.read")),
+            make_tool_rule("RULE-001", Some("fs.write")),
+        ]);
+
+        let result = validate_policy(&policy);
+        assert!(matches!(
+            result,
+            Err(PolicyError::DuplicateRuleId { rule_id }) if rule_id == "RULE-001"
+        ));
+    }
+
+    #[test]
+    fn test_validate_empty_name_fails() {
+        let mut policy = make_policy(vec![make_tool_rule("RULE-001", Some("fs.read"))]);
+        policy.name = String::new();
+
+        let result = validate_policy(&policy);
+        assert!(matches!(
+            result,
+            Err(PolicyError::MissingField { field }) if field == "name"
+        ));
+    }
+
+    #[test]
+    fn test_validate_invalid_version_fails() {
+        let mut policy = make_policy(vec![make_tool_rule("RULE-001", Some("fs.read"))]);
+        policy.version = "invalid".to_string();
+
+        let result = validate_policy(&policy);
+        assert!(matches!(result, Err(PolicyError::InvalidVersion { .. })));
+    }
+
+    #[test]
+    fn test_validate_tool_rule_requires_tool_or_paths() {
+        let policy = make_policy(vec![make_tool_rule("RULE-001", None)]);
+
+        let result = validate_policy(&policy);
+        assert!(matches!(result, Err(PolicyError::ValidationError { .. })));
+    }
+
+    #[test]
+    fn test_validate_tool_rule_with_paths_is_valid() {
+        let mut rule = make_tool_rule("RULE-001", None);
+        rule.paths = vec!["/workspace/**".to_string()];
+        let policy = make_policy(vec![rule]);
+
+        let result = validate_policy(&policy);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_tool_rule_with_commands_is_valid() {
+        let mut rule = make_tool_rule("RULE-001", None);
+        rule.commands = vec!["cargo *".to_string()];
+        let policy = make_policy(vec![rule]);
+
+        let result = validate_policy(&policy);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_budget_rule_requires_budget_type() {
+        let policy = make_policy(vec![make_budget_rule("RULE-001", None, Some(1000))]);
+
+        let result = validate_policy(&policy);
+        assert!(matches!(result, Err(PolicyError::ValidationError { .. })));
+    }
+
+    #[test]
+    fn test_validate_budget_rule_requires_limit() {
+        let policy = make_policy(vec![make_budget_rule(
+            "RULE-001",
+            Some(BudgetType::Token),
+            None,
+        )]);
+
+        let result = validate_policy(&policy);
+        assert!(matches!(result, Err(PolicyError::ValidationError { .. })));
+    }
+
+    #[test]
+    fn test_validate_budget_rule_rejects_zero_limit() {
+        let policy = make_policy(vec![make_budget_rule(
+            "RULE-001",
+            Some(BudgetType::Token),
+            Some(0),
+        )]);
+
+        let result = validate_policy(&policy);
+        assert!(matches!(result, Err(PolicyError::ValidationError { .. })));
+    }
+
+    #[test]
+    fn test_validate_valid_budget_rule() {
+        let policy = make_policy(vec![make_budget_rule(
+            "RULE-001",
+            Some(BudgetType::Token),
+            Some(100_000),
+        )]);
+
+        let result = validate_policy(&policy);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_network_rule_requires_hosts_or_ports() {
+        let rule = Rule {
+            id: "RULE-001".to_string(),
+            rule_type: RuleType::Network,
+            decision: Decision::Allow,
+            tool: None,
+            paths: vec![],
+            commands: vec![],
+            budget_type: None,
+            limit: None,
+            hosts: vec![],
+            ports: vec![],
+            condition: None,
+            rationale_code: None,
+            reason: None,
+        };
+        let policy = make_policy(vec![rule]);
+
+        let result = validate_policy(&policy);
+        assert!(matches!(result, Err(PolicyError::ValidationError { .. })));
+    }
+
+    #[test]
+    fn test_validate_network_rule_with_hosts_is_valid() {
+        let rule = Rule {
+            id: "RULE-001".to_string(),
+            rule_type: RuleType::Network,
+            decision: Decision::Allow,
+            tool: None,
+            paths: vec![],
+            commands: vec![],
+            budget_type: None,
+            limit: None,
+            hosts: vec!["api.example.com".to_string()],
+            ports: vec![],
+            condition: None,
+            rationale_code: None,
+            reason: None,
+        };
+        let policy = make_policy(vec![rule]);
+
+        let result = validate_policy(&policy);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_filesystem_rule_requires_paths() {
+        let rule = Rule {
+            id: "RULE-001".to_string(),
+            rule_type: RuleType::Filesystem,
+            decision: Decision::Allow,
+            tool: None,
+            paths: vec![],
+            commands: vec![],
+            budget_type: None,
+            limit: None,
+            hosts: vec![],
+            ports: vec![],
+            condition: None,
+            rationale_code: None,
+            reason: None,
+        };
+        let policy = make_policy(vec![rule]);
+
+        let result = validate_policy(&policy);
+        assert!(matches!(result, Err(PolicyError::ValidationError { .. })));
+    }
+
+    #[test]
+    fn test_validate_glob_pattern_empty() {
+        let result = validate_glob_pattern("RULE-001", "");
+        assert!(matches!(
+            result,
+            Err(PolicyError::InvalidGlobPattern { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_glob_pattern_unbalanced_brackets() {
+        let result = validate_glob_pattern("RULE-001", "[a-z");
+        assert!(matches!(
+            result,
+            Err(PolicyError::InvalidGlobPattern { .. })
+        ));
+
+        let result = validate_glob_pattern("RULE-001", "a-z]");
+        assert!(matches!(
+            result,
+            Err(PolicyError::InvalidGlobPattern { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_glob_pattern_unbalanced_braces() {
+        let result = validate_glob_pattern("RULE-001", "{a,b");
+        assert!(matches!(
+            result,
+            Err(PolicyError::InvalidGlobPattern { .. })
+        ));
+
+        let result = validate_glob_pattern("RULE-001", "a,b}");
+        assert!(matches!(
+            result,
+            Err(PolicyError::InvalidGlobPattern { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_glob_pattern_valid() {
+        assert!(validate_glob_pattern("RULE-001", "/workspace/**").is_ok());
+        assert!(validate_glob_pattern("RULE-001", "*.rs").is_ok());
+        assert!(validate_glob_pattern("RULE-001", "[a-z]*").is_ok());
+        assert!(validate_glob_pattern("RULE-001", "{foo,bar}").is_ok());
+        assert!(validate_glob_pattern("RULE-001", "\\[escaped\\]").is_ok());
+    }
+}

--- a/policy/default.yaml
+++ b/policy/default.yaml
@@ -1,0 +1,88 @@
+# APM2 Default Policy
+#
+# This is the default policy shipped with APM2. It follows a strict
+# default-deny model where all actions must be explicitly allowed.
+#
+# IMPORTANT: This policy is restrictive by design. Customize for your
+# use case by creating a project-specific policy file.
+
+policy:
+  version: "1.0.0"
+  name: "apm2-default"
+  description: "Default deny-all policy for APM2"
+
+  rules:
+    # ========================================================================
+    # FILESYSTEM RULES
+    # ========================================================================
+
+    # Allow reading from workspace (current directory and subdirectories)
+    - id: "fs-read-workspace"
+      type: filesystem
+      paths:
+        - "./**"
+      decision: allow
+      reason: "Allow reading workspace files"
+      rationale_code: "FS_READ_WORKSPACE"
+
+    # ========================================================================
+    # TOOL RULES
+    # ========================================================================
+
+    # Allow read-only filesystem operations
+    - id: "tool-fs-read"
+      type: tool_allow
+      tool: "fs.read"
+      paths:
+        - "./**"
+      decision: allow
+      reason: "Allow reading workspace files via fs.read tool"
+
+    # Allow glob/search operations
+    - id: "tool-fs-glob"
+      type: tool_allow
+      tool: "fs.glob"
+      paths:
+        - "./**"
+      decision: allow
+      reason: "Allow searching workspace files"
+
+    # Allow grep/search operations
+    - id: "tool-fs-grep"
+      type: tool_allow
+      tool: "fs.grep"
+      paths:
+        - "./**"
+      decision: allow
+      reason: "Allow searching file contents"
+
+    # ========================================================================
+    # BUDGET RULES
+    # ========================================================================
+
+    # Token budget for inference calls (100K tokens)
+    - id: "budget-tokens"
+      type: budget
+      budget_type: token
+      limit: 100000
+      decision: allow
+      reason: "Default token budget"
+
+    # Time budget (1 hour)
+    - id: "budget-time"
+      type: budget
+      budget_type: time
+      limit: 3600000
+      decision: allow
+      reason: "Default time budget (1 hour in milliseconds)"
+
+    # Tool call budget (1000 calls)
+    - id: "budget-tool-calls"
+      type: budget
+      budget_type: tool_calls
+      limit: 1000
+      decision: allow
+      reason: "Default tool call budget"
+
+  # Default decision: DENY everything not explicitly allowed
+  default_decision: deny

--- a/policy/development.yaml
+++ b/policy/development.yaml
@@ -1,0 +1,188 @@
+# APM2 Development Policy
+#
+# A more permissive policy suitable for local development environments.
+# This policy allows common development operations while still maintaining
+# some security boundaries.
+#
+# WARNING: This policy is more permissive than the default. Use with caution
+# and only in trusted development environments.
+
+policy:
+  version: "1.0.0"
+  name: "apm2-development"
+  description: "Permissive policy for local development"
+
+  rules:
+    # ========================================================================
+    # FILESYSTEM RULES
+    # ========================================================================
+
+    # Allow reading from workspace and common development paths
+    - id: "fs-read-workspace"
+      type: filesystem
+      paths:
+        - "./**"
+        - "/tmp/**"
+      decision: allow
+      reason: "Allow reading workspace and temp files"
+
+    # Allow writing to workspace (for code generation, etc.)
+    - id: "fs-write-workspace"
+      type: filesystem
+      paths:
+        - "./**"
+      decision: allow
+      reason: "Allow writing workspace files"
+
+    # ========================================================================
+    # TOOL RULES
+    # ========================================================================
+
+    # Allow all filesystem read operations in workspace
+    - id: "tool-fs-read"
+      type: tool_allow
+      tool: "fs.read"
+      paths:
+        - "./**"
+        - "/tmp/**"
+      decision: allow
+
+    # Allow filesystem write operations in workspace
+    - id: "tool-fs-write"
+      type: tool_allow
+      tool: "fs.write"
+      paths:
+        - "./**"
+      decision: allow
+
+    # Allow filesystem edit operations
+    - id: "tool-fs-edit"
+      type: tool_allow
+      tool: "fs.edit"
+      paths:
+        - "./**"
+      decision: allow
+
+    # Allow glob/search operations
+    - id: "tool-fs-glob"
+      type: tool_allow
+      tool: "fs.glob"
+      paths:
+        - "./**"
+      decision: allow
+
+    # Allow grep/search operations
+    - id: "tool-fs-grep"
+      type: tool_allow
+      tool: "fs.grep"
+      paths:
+        - "./**"
+      decision: allow
+
+    # Allow shell execution for common dev tools
+    - id: "tool-shell-dev"
+      type: tool_allow
+      tool: "shell.exec"
+      commands:
+        - "cargo *"
+        - "npm *"
+        - "yarn *"
+        - "pnpm *"
+        - "python *"
+        - "pip *"
+        - "git *"
+        - "make *"
+        - "ls *"
+        - "cat *"
+        - "head *"
+        - "tail *"
+        - "grep *"
+        - "find *"
+        - "wc *"
+      decision: allow
+      reason: "Allow common development commands"
+
+    # ========================================================================
+    # NETWORK RULES
+    # ========================================================================
+
+    # Allow HTTPS connections to common development APIs
+    - id: "network-dev-apis"
+      type: network
+      hosts:
+        - "api.github.com"
+        - "raw.githubusercontent.com"
+        - "crates.io"
+        - "static.crates.io"
+        - "index.crates.io"
+        - "registry.npmjs.org"
+        - "pypi.org"
+      ports:
+        - 443
+      decision: allow
+      reason: "Allow package registry access"
+
+    # Allow inference API access
+    - id: "network-inference"
+      type: network
+      hosts:
+        - "api.anthropic.com"
+        - "api.openai.com"
+      ports:
+        - 443
+      decision: allow
+      reason: "Allow inference API access"
+
+    # ========================================================================
+    # BUDGET RULES
+    # ========================================================================
+
+    # Higher token budget for development (500K tokens)
+    - id: "budget-tokens"
+      type: budget
+      budget_type: token
+      limit: 500000
+      decision: allow
+      reason: "Development token budget"
+
+    # Extended time budget (4 hours)
+    - id: "budget-time"
+      type: budget
+      budget_type: time
+      limit: 14400000
+      decision: allow
+      reason: "Development time budget (4 hours)"
+
+    # Higher tool call budget (5000 calls)
+    - id: "budget-tool-calls"
+      type: budget
+      budget_type: tool_calls
+      limit: 5000
+      decision: allow
+      reason: "Development tool call budget"
+
+    # Filesystem operations budget
+    - id: "budget-fs-ops"
+      type: budget
+      budget_type: filesystem_ops
+      limit: 10000
+      decision: allow
+
+    # Network operations budget
+    - id: "budget-network-ops"
+      type: budget
+      budget_type: network_ops
+      limit: 1000
+      decision: allow
+
+    # ========================================================================
+    # INFERENCE RULES
+    # ========================================================================
+
+    - id: "inference-allowed"
+      type: inference
+      decision: allow
+      reason: "Allow inference calls in development"
+
+  # Default decision: DENY everything not explicitly allowed
+  default_decision: deny

--- a/policy/restricted.yaml
+++ b/policy/restricted.yaml
@@ -1,0 +1,133 @@
+# APM2 Restricted Policy
+#
+# A highly restrictive policy for security-sensitive environments.
+# This policy provides minimal permissions and is suitable for
+# auditing or reviewing code without allowing modifications.
+#
+# Use this policy when you want maximum safety at the cost of
+# functionality.
+
+policy:
+  version: "1.0.0"
+  name: "apm2-restricted"
+  description: "Highly restrictive read-only policy"
+
+  rules:
+    # ========================================================================
+    # FILESYSTEM RULES - Read Only
+    # ========================================================================
+
+    # Allow reading from workspace only
+    - id: "fs-read-workspace"
+      type: filesystem
+      paths:
+        - "./**"
+      decision: allow
+      reason: "Allow reading workspace files only"
+      rationale_code: "RESTRICTED_FS_READ"
+
+    # ========================================================================
+    # TOOL RULES - Read Only
+    # ========================================================================
+
+    # Allow read-only filesystem operations
+    - id: "tool-fs-read"
+      type: tool_allow
+      tool: "fs.read"
+      paths:
+        - "./**"
+      decision: allow
+      rationale_code: "RESTRICTED_FS_READ_TOOL"
+
+    # Allow glob/search operations
+    - id: "tool-fs-glob"
+      type: tool_allow
+      tool: "fs.glob"
+      paths:
+        - "./**"
+      decision: allow
+
+    # Allow grep/search operations
+    - id: "tool-fs-grep"
+      type: tool_allow
+      tool: "fs.grep"
+      paths:
+        - "./**"
+      decision: allow
+
+    # Explicitly deny all write operations
+    - id: "deny-fs-write"
+      type: tool_deny
+      tool: "fs.write"
+      decision: deny
+      rationale_code: "RESTRICTED_NO_WRITE"
+
+    - id: "deny-fs-edit"
+      type: tool_deny
+      tool: "fs.edit"
+      decision: deny
+      rationale_code: "RESTRICTED_NO_EDIT"
+
+    # Deny shell execution
+    - id: "deny-shell"
+      type: tool_deny
+      tool: "shell.exec"
+      decision: deny
+      rationale_code: "RESTRICTED_NO_SHELL"
+
+    # ========================================================================
+    # NETWORK RULES - Deny All
+    # ========================================================================
+
+    # Network access is completely disabled in restricted mode
+    # (Handled by default_decision: deny)
+
+    # ========================================================================
+    # BUDGET RULES - Minimal
+    # ========================================================================
+
+    # Minimal token budget (10K tokens)
+    - id: "budget-tokens"
+      type: budget
+      budget_type: token
+      limit: 10000
+      decision: allow
+      reason: "Minimal token budget for analysis"
+
+    # Short time budget (15 minutes)
+    - id: "budget-time"
+      type: budget
+      budget_type: time
+      limit: 900000
+      decision: allow
+      reason: "Short time budget (15 minutes)"
+
+    # Low tool call budget (100 calls)
+    - id: "budget-tool-calls"
+      type: budget
+      budget_type: tool_calls
+      limit: 100
+      decision: allow
+      reason: "Minimal tool call budget"
+
+    # ========================================================================
+    # SECRETS RULES - Deny All
+    # ========================================================================
+
+    - id: "deny-secrets"
+      type: secrets
+      decision: deny
+      rationale_code: "RESTRICTED_NO_SECRETS"
+
+    # ========================================================================
+    # INFERENCE RULES - Limited
+    # ========================================================================
+
+    - id: "inference-limited"
+      type: inference
+      decision: allow
+      reason: "Allow limited inference for analysis"
+      rationale_code: "RESTRICTED_INFERENCE"
+
+  # Default decision: DENY everything not explicitly allowed
+  default_decision: deny


### PR DESCRIPTION
## Summary

Implements ticket TCK-00009 as part of the xtask development automation.

## Ticket

See `documents/work/tickets/TCK-00009.yaml` for requirements.

## Test Plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test -p xtask` passes
- [ ] Manual testing of the new command
