### PR TITLE
feat(TCK-00012): implement audit event emission

### DIFF
--- a/crates/apm2-core/src/config/AGENTS.md
+++ b/crates/apm2-core/src/config/AGENTS.md
@@ -51,12 +51,29 @@ pub struct DaemonConfig {
     pub log_dir: PathBuf,       // Default: /var/log/apm2
     #[serde(default = "default_state_file")]
     pub state_file: PathBuf,    // Default: /var/lib/apm2/state.json
+    #[serde(default)]
+    pub audit: AuditConfig,     // Audit event retention policy
 }
 ```
 
 **Invariants:**
 - [INV-CFG-03] All paths have sensible FHS-compliant defaults for Unix systems
 - [INV-CFG-04] `Default` implementation matches field-level `serde(default)` behavior
+
+### `AuditConfig`
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditConfig {
+    #[serde(default = "default_audit_retention_days")]
+    pub retention_days: u32,    // Default: 30 days
+    #[serde(default = "default_audit_max_size_bytes")]
+    pub max_size_bytes: u64,    // Default: 1 GB
+}
+```
+
+**Invariants:**
+- [INV-CFG-09] Retention policy defaults to 30 days / 1GB to prevent disk exhaustion
 
 ### `CredentialProfileConfig`
 


### PR DESCRIPTION
## Summary

Implement audit event emission support for policy violations and audit configuration:

- **AuditConfig**: Added retention configuration to `DaemonConfig`.
- **PolicyViolation**: Added helper to create violation events.
- **EvaluationResult**: Added conversion to  events for denied requests.

### Ticket Binding

- **Ticket**: TCK-00012 - Implement audit event emission
- **RFC**: RFC-0001
- **Binds**: REQ-0017, REQ-0023, REQ-0027, REQ-1005
- **Evidence**: EVID-0011, EVID-0012

### Definition of Done

- [x] PolicyViolation events emitted on violations (helper implemented)
- [x] All events include rationale_code (via EvaluationResult)
- [x] Retention policy documented (AuditConfig)
- [ ] Structured logs via tracing (Capability verified)

## Test plan

- [x] `cargo test -p apm2-core policy::` - Verify event creation and conversion
- [x] `cargo test -p apm2-core config::` - Verify config parsing
- [x] `cargo clippy` - No warnings

## Dependencies

- Based on PR #110 (TCK-00011). Merge #110 first.
