### PR TITLE
feat(TCK-00119): implement run manifest with signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ name = "apm2-core"
 version = "0.3.0"
 dependencies = [
  "axum",
+ "base64",
  "blake3",
  "bytes",
  "chrono",
@@ -282,6 +283,12 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ shell-words = "1.1"
 
 # Utilities
 glob = "0.3"
-uuid = { version = "1.0", features = ["v4", "serde"] }
+uuid = { version = "1.0", features = ["v4", "v7", "serde"] }
 nix = { version = "0.30", features = ["signal", "process", "fs"] }
 wait-timeout = "0.2"
 directories = "6"
@@ -89,6 +89,7 @@ prost-types = "0.13"
 prost-build = "0.13"
 
 # Cryptography
+base64 = "0.22"
 blake3 = "1.5"
 hex = "0.4"
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }

--- a/crates/apm2-core/Cargo.toml
+++ b/crates/apm2-core/Cargo.toml
@@ -60,6 +60,7 @@ prost.workspace = true
 prost-types.workspace = true
 
 # Cryptography
+base64.workspace = true
 blake3.workspace = true
 hex.workspace = true
 ed25519-dalek.workspace = true

--- a/crates/apm2-core/src/lib.rs
+++ b/crates/apm2-core/src/lib.rs
@@ -55,6 +55,7 @@ pub mod process;
 pub mod reducer;
 pub mod restart;
 pub mod rfc_framer;
+pub mod run_manifest;
 pub mod session;
 pub mod shutdown;
 pub mod state;

--- a/crates/apm2-core/src/run_manifest/manifest.rs
+++ b/crates/apm2-core/src/run_manifest/manifest.rs
@@ -1,0 +1,506 @@
+//! Run manifest data structures and builder.
+//!
+//! This module defines the [`RunManifest`] struct that captures a complete
+//! record of a pipeline execution, including input/output hashes, routing
+//! decisions, and stage timings.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::crypto::EventHasher;
+
+/// Errors that can occur during manifest construction.
+#[derive(Debug, Error)]
+pub enum ManifestError {
+    /// A required field was not provided.
+    #[error("missing required field: {field}")]
+    MissingField {
+        /// The name of the missing field.
+        field: &'static str,
+    },
+
+    /// An invalid value was provided.
+    #[error("invalid value for {field}: {reason}")]
+    InvalidValue {
+        /// The name of the field.
+        field: &'static str,
+        /// The reason the value is invalid.
+        reason: String,
+    },
+}
+
+/// A run manifest capturing a complete record of pipeline execution.
+///
+/// Manifests are designed to be cryptographically signed for verification
+/// and reproducibility auditing. All fields use deterministic ordering
+/// (`BTreeMap`) to ensure consistent canonicalization for signing.
+///
+/// # Fields
+///
+/// - `manifest_id`: UUID v7 for temporal ordering
+/// - `lease_id`: Identifies the pipeline execution session
+/// - `created_at`: ISO 8601 timestamp
+/// - `input_hashes`: Map of input artifact paths to BLAKE3 hashes
+/// - `output_hashes`: Map of output artifact paths to BLAKE3 hashes
+/// - `routing_profile_id`: Which routing profile was used
+/// - `routing_decisions`: Map of stage name to provider used
+/// - `stage_timings`: Map of stage name to duration in milliseconds
+/// - `ccp_index_hash`: Hash of the CCP index used as grounding
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RunManifest {
+    /// Unique identifier for this manifest (UUID v7 for temporal ordering).
+    pub manifest_id: String,
+
+    /// The lease ID identifying the pipeline execution session.
+    pub lease_id: String,
+
+    /// Timestamp when this manifest was created (ISO 8601).
+    pub created_at: DateTime<Utc>,
+
+    /// Map of input artifact paths to their BLAKE3 hashes (hex-encoded).
+    pub input_hashes: BTreeMap<String, String>,
+
+    /// Map of output artifact paths to their BLAKE3 hashes (hex-encoded).
+    pub output_hashes: BTreeMap<String, String>,
+
+    /// The routing profile ID that was used for this execution.
+    pub routing_profile_id: String,
+
+    /// Map of stage name to the provider that was used.
+    pub routing_decisions: BTreeMap<String, String>,
+
+    /// Map of stage name to execution duration in milliseconds.
+    pub stage_timings: BTreeMap<String, u64>,
+
+    /// BLAKE3 hash of the CCP index used as grounding (hex-encoded).
+    pub ccp_index_hash: String,
+}
+
+impl RunManifest {
+    /// Returns the canonical JSON representation of this manifest.
+    ///
+    /// This is the byte sequence that should be signed. The representation
+    /// uses sorted keys and consistent formatting to ensure determinism.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the manifest cannot be serialized to JSON, which should
+    /// never happen for valid manifests.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        // serde_json with BTreeMap produces sorted keys
+        serde_json::to_vec(self).expect("manifest serialization should not fail")
+    }
+
+    /// Computes the BLAKE3 hash of the canonical representation.
+    #[must_use]
+    pub fn content_hash(&self) -> [u8; 32] {
+        EventHasher::hash_content(&self.canonical_bytes())
+    }
+}
+
+/// Builder for constructing [`RunManifest`] instances with validation.
+///
+/// # Example
+///
+/// ```rust
+/// use apm2_core::run_manifest::ManifestBuilder;
+///
+/// let manifest = ManifestBuilder::new()
+///     .with_lease_id("lease-123")
+///     .with_routing_profile_id("production")
+///     .with_ccp_index_hash("abc123...")
+///     .add_input("input.yaml", b"content")
+///     .add_output("output.yaml", b"result")
+///     .record_routing_decision("impact_map", "claude-opus-4")
+///     .record_stage_timing("impact_map", 1500)
+///     .build()
+///     .unwrap();
+/// ```
+#[derive(Debug, Default)]
+pub struct ManifestBuilder {
+    lease_id: Option<String>,
+    routing_profile_id: Option<String>,
+    ccp_index_hash: Option<String>,
+    input_hashes: BTreeMap<String, String>,
+    output_hashes: BTreeMap<String, String>,
+    routing_decisions: BTreeMap<String, String>,
+    stage_timings: BTreeMap<String, u64>,
+}
+
+impl ManifestBuilder {
+    /// Creates a new manifest builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the lease ID for this manifest.
+    #[must_use]
+    pub fn with_lease_id(mut self, lease_id: impl Into<String>) -> Self {
+        self.lease_id = Some(lease_id.into());
+        self
+    }
+
+    /// Sets the routing profile ID for this manifest.
+    #[must_use]
+    pub fn with_routing_profile_id(mut self, profile_id: impl Into<String>) -> Self {
+        self.routing_profile_id = Some(profile_id.into());
+        self
+    }
+
+    /// Sets the CCP index hash for this manifest.
+    ///
+    /// The hash should be a hex-encoded BLAKE3 hash.
+    #[must_use]
+    pub fn with_ccp_index_hash(mut self, hash: impl Into<String>) -> Self {
+        self.ccp_index_hash = Some(hash.into());
+        self
+    }
+
+    /// Adds an input artifact by computing its BLAKE3 hash.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the input artifact
+    /// * `content` - The raw content of the artifact
+    #[must_use]
+    pub fn add_input(mut self, path: impl Into<String>, content: &[u8]) -> Self {
+        let hash = EventHasher::hash_content(content);
+        self.input_hashes.insert(path.into(), hex::encode(hash));
+        self
+    }
+
+    /// Adds an input artifact with a pre-computed hash.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the input artifact
+    /// * `hash` - The hex-encoded BLAKE3 hash
+    #[must_use]
+    pub fn add_input_hash(mut self, path: impl Into<String>, hash: impl Into<String>) -> Self {
+        self.input_hashes.insert(path.into(), hash.into());
+        self
+    }
+
+    /// Adds an output artifact by computing its BLAKE3 hash.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the output artifact
+    /// * `content` - The raw content of the artifact
+    #[must_use]
+    pub fn add_output(mut self, path: impl Into<String>, content: &[u8]) -> Self {
+        let hash = EventHasher::hash_content(content);
+        self.output_hashes.insert(path.into(), hex::encode(hash));
+        self
+    }
+
+    /// Adds an output artifact with a pre-computed hash.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the output artifact
+    /// * `hash` - The hex-encoded BLAKE3 hash
+    #[must_use]
+    pub fn add_output_hash(mut self, path: impl Into<String>, hash: impl Into<String>) -> Self {
+        self.output_hashes.insert(path.into(), hash.into());
+        self
+    }
+
+    /// Records a routing decision for a pipeline stage.
+    ///
+    /// # Arguments
+    ///
+    /// * `stage` - The name of the pipeline stage
+    /// * `provider` - The provider that was used for this stage
+    #[must_use]
+    pub fn record_routing_decision(
+        mut self,
+        stage: impl Into<String>,
+        provider: impl Into<String>,
+    ) -> Self {
+        self.routing_decisions.insert(stage.into(), provider.into());
+        self
+    }
+
+    /// Records the execution timing for a pipeline stage.
+    ///
+    /// # Arguments
+    ///
+    /// * `stage` - The name of the pipeline stage
+    /// * `duration_ms` - The execution duration in milliseconds
+    #[must_use]
+    pub fn record_stage_timing(mut self, stage: impl Into<String>, duration_ms: u64) -> Self {
+        self.stage_timings.insert(stage.into(), duration_ms);
+        self
+    }
+
+    /// Builds the manifest, validating all required fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ManifestError::MissingField`] if any required field is not
+    /// set.
+    pub fn build(self) -> Result<RunManifest, ManifestError> {
+        let lease_id = self
+            .lease_id
+            .ok_or(ManifestError::MissingField { field: "lease_id" })?;
+
+        let routing_profile_id = self.routing_profile_id.ok_or(ManifestError::MissingField {
+            field: "routing_profile_id",
+        })?;
+
+        let ccp_index_hash = self.ccp_index_hash.ok_or(ManifestError::MissingField {
+            field: "ccp_index_hash",
+        })?;
+
+        // Generate UUID v7 for temporal ordering
+        let manifest_id = Uuid::now_v7().to_string();
+
+        Ok(RunManifest {
+            manifest_id,
+            lease_id,
+            created_at: Utc::now(),
+            input_hashes: self.input_hashes,
+            output_hashes: self.output_hashes,
+            routing_profile_id,
+            routing_decisions: self.routing_decisions,
+            stage_timings: self.stage_timings,
+            ccp_index_hash,
+        })
+    }
+
+    /// Builds the manifest with a specific manifest ID and timestamp.
+    ///
+    /// This is primarily for testing and replay scenarios where
+    /// deterministic values are needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ManifestError::MissingField`] if any required field is not
+    /// set.
+    pub fn build_with_id(
+        self,
+        manifest_id: impl Into<String>,
+        created_at: DateTime<Utc>,
+    ) -> Result<RunManifest, ManifestError> {
+        let lease_id = self
+            .lease_id
+            .ok_or(ManifestError::MissingField { field: "lease_id" })?;
+
+        let routing_profile_id = self.routing_profile_id.ok_or(ManifestError::MissingField {
+            field: "routing_profile_id",
+        })?;
+
+        let ccp_index_hash = self.ccp_index_hash.ok_or(ManifestError::MissingField {
+            field: "ccp_index_hash",
+        })?;
+
+        Ok(RunManifest {
+            manifest_id: manifest_id.into(),
+            lease_id,
+            created_at,
+            input_hashes: self.input_hashes,
+            output_hashes: self.output_hashes,
+            routing_profile_id,
+            routing_decisions: self.routing_decisions,
+            stage_timings: self.stage_timings,
+            ccp_index_hash,
+        })
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    fn create_test_manifest() -> RunManifest {
+        let created_at = Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap();
+
+        ManifestBuilder::new()
+            .with_lease_id("lease-abc123")
+            .with_routing_profile_id("production")
+            .with_ccp_index_hash("deadbeef")
+            .add_input("requirements.yaml", b"requirement content")
+            .add_output("impact_map.yaml", b"impact map content")
+            .record_routing_decision("impact_map", "claude-opus-4")
+            .record_stage_timing("impact_map", 1500)
+            .build_with_id("manifest-001", created_at)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_manifest_builder_success() {
+        let manifest = create_test_manifest();
+
+        assert_eq!(manifest.manifest_id, "manifest-001");
+        assert_eq!(manifest.lease_id, "lease-abc123");
+        assert_eq!(manifest.routing_profile_id, "production");
+        assert_eq!(manifest.ccp_index_hash, "deadbeef");
+        assert_eq!(manifest.input_hashes.len(), 1);
+        assert_eq!(manifest.output_hashes.len(), 1);
+        assert_eq!(manifest.routing_decisions.len(), 1);
+        assert_eq!(manifest.stage_timings.len(), 1);
+        assert_eq!(
+            manifest.routing_decisions.get("impact_map"),
+            Some(&"claude-opus-4".to_string())
+        );
+        assert_eq!(manifest.stage_timings.get("impact_map"), Some(&1500));
+    }
+
+    #[test]
+    fn test_manifest_builder_missing_lease_id() {
+        let result = ManifestBuilder::new()
+            .with_routing_profile_id("production")
+            .with_ccp_index_hash("deadbeef")
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(ManifestError::MissingField { field: "lease_id" })
+        ));
+    }
+
+    #[test]
+    fn test_manifest_builder_missing_routing_profile_id() {
+        let result = ManifestBuilder::new()
+            .with_lease_id("lease-123")
+            .with_ccp_index_hash("deadbeef")
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(ManifestError::MissingField {
+                field: "routing_profile_id"
+            })
+        ));
+    }
+
+    #[test]
+    fn test_manifest_builder_missing_ccp_index_hash() {
+        let result = ManifestBuilder::new()
+            .with_lease_id("lease-123")
+            .with_routing_profile_id("production")
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(ManifestError::MissingField {
+                field: "ccp_index_hash"
+            })
+        ));
+    }
+
+    #[test]
+    fn test_manifest_canonical_bytes_deterministic() {
+        let manifest1 = create_test_manifest();
+        let manifest2 = create_test_manifest();
+
+        assert_eq!(manifest1.canonical_bytes(), manifest2.canonical_bytes());
+    }
+
+    #[test]
+    fn test_manifest_content_hash_deterministic() {
+        let manifest1 = create_test_manifest();
+        let manifest2 = create_test_manifest();
+
+        assert_eq!(manifest1.content_hash(), manifest2.content_hash());
+    }
+
+    #[test]
+    fn test_manifest_serialization_roundtrip() {
+        let manifest = create_test_manifest();
+        let json = serde_json::to_string(&manifest).unwrap();
+        let deserialized: RunManifest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(manifest, deserialized);
+    }
+
+    #[test]
+    fn test_manifest_btree_ordering() {
+        // BTreeMap ensures deterministic ordering regardless of insertion order
+        let created_at = Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap();
+
+        let manifest1 = ManifestBuilder::new()
+            .with_lease_id("lease-123")
+            .with_routing_profile_id("production")
+            .with_ccp_index_hash("hash")
+            .add_input_hash("z_input.yaml", "hash_z")
+            .add_input_hash("a_input.yaml", "hash_a")
+            .build_with_id("id", created_at)
+            .unwrap();
+
+        let manifest2 = ManifestBuilder::new()
+            .with_lease_id("lease-123")
+            .with_routing_profile_id("production")
+            .with_ccp_index_hash("hash")
+            .add_input_hash("a_input.yaml", "hash_a")
+            .add_input_hash("z_input.yaml", "hash_z")
+            .build_with_id("id", created_at)
+            .unwrap();
+
+        assert_eq!(manifest1.canonical_bytes(), manifest2.canonical_bytes());
+    }
+
+    #[test]
+    fn test_manifest_build_generates_uuid_v7() {
+        let manifest = ManifestBuilder::new()
+            .with_lease_id("lease-123")
+            .with_routing_profile_id("production")
+            .with_ccp_index_hash("hash")
+            .build()
+            .unwrap();
+
+        // UUID v7 should be parseable and have the correct version
+        let uuid = Uuid::parse_str(&manifest.manifest_id).unwrap();
+        assert_eq!(uuid.get_version_num(), 7);
+    }
+
+    #[test]
+    fn test_add_input_computes_hash() {
+        let created_at = Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap();
+        let content = b"test content";
+
+        let manifest = ManifestBuilder::new()
+            .with_lease_id("lease-123")
+            .with_routing_profile_id("production")
+            .with_ccp_index_hash("hash")
+            .add_input("test.yaml", content)
+            .build_with_id("id", created_at)
+            .unwrap();
+
+        let expected_hash = EventHasher::hash_content(content);
+        assert_eq!(
+            manifest.input_hashes.get("test.yaml"),
+            Some(&hex::encode(expected_hash))
+        );
+    }
+
+    #[test]
+    fn test_add_output_computes_hash() {
+        let created_at = Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap();
+        let content = b"output content";
+
+        let manifest = ManifestBuilder::new()
+            .with_lease_id("lease-123")
+            .with_routing_profile_id("production")
+            .with_ccp_index_hash("hash")
+            .add_output("output.yaml", content)
+            .build_with_id("id", created_at)
+            .unwrap();
+
+        let expected_hash = EventHasher::hash_content(content);
+        assert_eq!(
+            manifest.output_hashes.get("output.yaml"),
+            Some(&hex::encode(expected_hash))
+        );
+    }
+}

--- a/crates/apm2-core/src/run_manifest/mod.rs
+++ b/crates/apm2-core/src/run_manifest/mod.rs
@@ -1,0 +1,78 @@
+//! Run manifest generation and signing for pipeline execution records.
+//!
+//! This module provides the infrastructure for creating cryptographically
+//! signed records of pipeline execution. Manifests capture input/output hashes,
+//! routing decisions, stage timings, and are signed with Ed25519 to enable
+//! verification and reproducibility auditing.
+//!
+//! # Overview
+//!
+//! A run manifest is a complete record of a single pipeline execution,
+//! including:
+//!
+//! - **Input artifacts**: BLAKE3 hashes of all input files
+//! - **Output artifacts**: BLAKE3 hashes of all generated files
+//! - **Routing decisions**: Which provider handled each pipeline stage
+//! - **Timing information**: Duration of each stage in milliseconds
+//! - **CCP grounding**: Hash of the CCP index used for context
+//!
+//! # Signing
+//!
+//! Manifests are signed using Ed25519 signatures from the [`crate::crypto`]
+//! module. The signing process:
+//!
+//! 1. Serializes the manifest to canonical JSON (sorted keys)
+//! 2. Signs the JSON bytes with Ed25519
+//! 3. Bundles the bytes, signature, and public key into a [`SignedManifest`]
+//!
+//! # Invariants
+//!
+//! - [INV-0001] Manifests are deterministically serialized (`BTreeMap`
+//!   ordering)
+//! - [INV-0002] UUID v7 manifest IDs enable temporal ordering
+//! - [INV-0003] Signatures cover the canonical representation
+//! - [INV-0004] All BLAKE3 hashes are hex-encoded
+//!
+//! # Contracts
+//!
+//! - [CTR-0001] `ManifestBuilder` requires `lease_id`, `routing_profile_id`,
+//!   and `ccp_index_hash`
+//! - [CTR-0002] `verify_manifest` fails if signature doesn't match bytes
+//! - [CTR-0003] `verify_manifest_with_key` fails if public key doesn't match
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use apm2_core::crypto::Signer;
+//! use apm2_core::run_manifest::{
+//!     ManifestBuilder, sign_manifest, verify_manifest,
+//! };
+//!
+//! // Build a manifest
+//! let manifest = ManifestBuilder::new()
+//!     .with_lease_id("lease-abc123")
+//!     .with_routing_profile_id("production")
+//!     .with_ccp_index_hash("deadbeef")
+//!     .add_input("requirements.yaml", b"requirement content")
+//!     .add_output("impact_map.yaml", b"generated output")
+//!     .record_routing_decision("impact_map", "claude-opus-4")
+//!     .record_stage_timing("impact_map", 1500)
+//!     .build()
+//!     .unwrap();
+//!
+//! // Sign the manifest
+//! let signer = Signer::generate();
+//! let signed = sign_manifest(&manifest, &signer);
+//!
+//! // Verify and extract the manifest
+//! let verified = verify_manifest(&signed).unwrap();
+//! assert_eq!(verified.lease_id, "lease-abc123");
+//! ```
+
+mod manifest;
+mod signer;
+
+pub use manifest::{ManifestBuilder, ManifestError, RunManifest};
+pub use signer::{
+    ManifestSignerError, SignedManifest, sign_manifest, verify_manifest, verify_manifest_with_key,
+};

--- a/crates/apm2-core/src/run_manifest/signer.rs
+++ b/crates/apm2-core/src/run_manifest/signer.rs
@@ -1,0 +1,383 @@
+//! Ed25519 signing and verification for run manifests.
+//!
+//! This module provides cryptographic signing of manifests using Ed25519,
+//! reusing the signing infrastructure from [`crate::crypto`].
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::manifest::RunManifest;
+use crate::crypto::{Signer, SignerError, VerifyingKey, parse_signature, verify_signature};
+
+/// Errors that can occur during manifest signing operations.
+#[derive(Debug, Error)]
+pub enum ManifestSignerError {
+    /// The signature is invalid or verification failed.
+    #[error("signature verification failed: {0}")]
+    VerificationFailed(String),
+
+    /// The manifest could not be deserialized.
+    #[error("manifest deserialization failed: {0}")]
+    DeserializationFailed(String),
+
+    /// An underlying signer error occurred.
+    #[error("signer error: {0}")]
+    SignerError(#[from] SignerError),
+}
+
+/// A signed run manifest containing the serialized manifest and its signature.
+///
+/// The signature is computed over the canonical JSON representation of the
+/// manifest. This struct is suitable for storage and transmission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedManifest {
+    /// The canonical JSON bytes of the manifest.
+    #[serde(with = "base64_bytes")]
+    pub manifest_bytes: Vec<u8>,
+
+    /// The Ed25519 signature over the manifest bytes.
+    #[serde(with = "base64_bytes")]
+    pub signature: Vec<u8>,
+
+    /// The public key that can verify this signature (hex-encoded).
+    pub public_key: String,
+}
+
+/// Serde helper module for base64 encoding/decoding of byte vectors.
+mod base64_bytes {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    const ENGINE: base64::engine::GeneralPurpose = base64::engine::general_purpose::STANDARD;
+
+    pub fn serialize<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use base64::Engine;
+        let encoded = ENGINE.encode(bytes);
+        encoded.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use base64::Engine;
+        let s = String::deserialize(deserializer)?;
+        ENGINE.decode(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl SignedManifest {
+    /// Returns the manifest ID extracted from the manifest bytes.
+    ///
+    /// This is a convenience method that deserializes just enough to get
+    /// the ID without full validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the manifest bytes cannot be deserialized.
+    pub fn manifest_id(&self) -> Result<String, ManifestSignerError> {
+        let manifest: RunManifest = serde_json::from_slice(&self.manifest_bytes)
+            .map_err(|e| ManifestSignerError::DeserializationFailed(e.to_string()))?;
+        Ok(manifest.manifest_id)
+    }
+}
+
+/// Signs a run manifest using the provided signer.
+///
+/// The manifest is first serialized to its canonical JSON representation,
+/// then signed using Ed25519. The resulting [`SignedManifest`] contains
+/// the serialized bytes, signature, and public key for verification.
+///
+/// # Arguments
+///
+/// * `manifest` - The manifest to sign
+/// * `signer` - The Ed25519 signer (contains the signing key)
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use apm2_core::crypto::Signer;
+/// use apm2_core::run_manifest::{ManifestBuilder, sign_manifest};
+///
+/// let signer = Signer::generate();
+/// let manifest = ManifestBuilder::new()
+///     .with_lease_id("lease-123")
+///     .with_routing_profile_id("production")
+///     .with_ccp_index_hash("abc123")
+///     .build()
+///     .unwrap();
+///
+/// let signed = sign_manifest(&manifest, &signer);
+/// ```
+#[must_use]
+pub fn sign_manifest(manifest: &RunManifest, signer: &Signer) -> SignedManifest {
+    let manifest_bytes = manifest.canonical_bytes();
+    let signature = signer.sign(&manifest_bytes);
+
+    SignedManifest {
+        manifest_bytes,
+        signature: signature.to_bytes().to_vec(),
+        public_key: hex::encode(signer.public_key_bytes()),
+    }
+}
+
+/// Verifies a signed manifest and returns the contained manifest if valid.
+///
+/// This function:
+/// 1. Parses the public key from the signed manifest
+/// 2. Verifies the signature over the manifest bytes
+/// 3. Deserializes and returns the manifest if valid
+///
+/// # Arguments
+///
+/// * `signed` - The signed manifest to verify
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The public key cannot be parsed
+/// - The signature is invalid
+/// - The manifest cannot be deserialized
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use apm2_core::run_manifest::verify_manifest;
+///
+/// # fn example(signed: apm2_core::run_manifest::SignedManifest) {
+/// match verify_manifest(&signed) {
+///     Ok(manifest) => println!("Valid manifest: {}", manifest.manifest_id),
+///     Err(e) => println!("Verification failed: {}", e),
+/// }
+/// # }
+/// ```
+pub fn verify_manifest(signed: &SignedManifest) -> Result<RunManifest, ManifestSignerError> {
+    // Parse the public key
+    let public_key_bytes = hex::decode(&signed.public_key)
+        .map_err(|e| ManifestSignerError::VerificationFailed(format!("invalid public key: {e}")))?;
+
+    let verifying_key = crate::crypto::parse_verifying_key(&public_key_bytes)?;
+
+    // Parse the signature
+    let signature = parse_signature(&signed.signature)?;
+
+    // Verify the signature
+    verify_signature(&verifying_key, &signed.manifest_bytes, &signature)?;
+
+    // Deserialize the manifest
+    let manifest: RunManifest = serde_json::from_slice(&signed.manifest_bytes)
+        .map_err(|e| ManifestSignerError::DeserializationFailed(e.to_string()))?;
+
+    Ok(manifest)
+}
+
+/// Verifies a signed manifest using a specific public key.
+///
+/// Unlike [`verify_manifest`], this function allows specifying an expected
+/// public key, which is useful when you want to verify that a manifest was
+/// signed by a specific actor.
+///
+/// # Arguments
+///
+/// * `signed` - The signed manifest to verify
+/// * `expected_key` - The expected public key
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The public key in the signed manifest doesn't match the expected key
+/// - The signature is invalid
+/// - The manifest cannot be deserialized
+pub fn verify_manifest_with_key(
+    signed: &SignedManifest,
+    expected_key: &VerifyingKey,
+) -> Result<RunManifest, ManifestSignerError> {
+    // Check that the public key matches
+    let expected_hex = hex::encode(expected_key.to_bytes());
+    if signed.public_key != expected_hex {
+        return Err(ManifestSignerError::VerificationFailed(format!(
+            "public key mismatch: expected {}, got {}",
+            expected_hex, signed.public_key
+        )));
+    }
+
+    // Parse the signature
+    let signature = parse_signature(&signed.signature)?;
+
+    // Verify the signature
+    verify_signature(expected_key, &signed.manifest_bytes, &signature)?;
+
+    // Deserialize the manifest
+    let manifest: RunManifest = serde_json::from_slice(&signed.manifest_bytes)
+        .map_err(|e| ManifestSignerError::DeserializationFailed(e.to_string()))?;
+
+    Ok(manifest)
+}
+
+#[cfg(test)]
+#[allow(clippy::similar_names)]
+mod unit_tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+    use crate::run_manifest::ManifestBuilder;
+
+    fn create_test_manifest() -> RunManifest {
+        let created_at = Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap();
+
+        ManifestBuilder::new()
+            .with_lease_id("lease-abc123")
+            .with_routing_profile_id("production")
+            .with_ccp_index_hash("deadbeef")
+            .add_input("requirements.yaml", b"requirement content")
+            .add_output("impact_map.yaml", b"impact map content")
+            .record_routing_decision("impact_map", "claude-opus-4")
+            .record_stage_timing("impact_map", 1500)
+            .build_with_id("manifest-001", created_at)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_sign_and_verify_roundtrip() {
+        let signer = Signer::generate();
+        let manifest = create_test_manifest();
+
+        let signed = sign_manifest(&manifest, &signer);
+        let verified = verify_manifest(&signed).unwrap();
+
+        assert_eq!(manifest, verified);
+    }
+
+    #[test]
+    fn test_verify_detects_tampered_manifest() {
+        let signer = Signer::generate();
+        let manifest = create_test_manifest();
+
+        let mut signed = sign_manifest(&manifest, &signer);
+
+        // Tamper with the manifest bytes
+        if !signed.manifest_bytes.is_empty() {
+            signed.manifest_bytes[0] ^= 0xff;
+        }
+
+        let result = verify_manifest(&signed);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_detects_tampered_signature() {
+        let signer = Signer::generate();
+        let manifest = create_test_manifest();
+
+        let mut signed = sign_manifest(&manifest, &signer);
+
+        // Tamper with the signature
+        if !signed.signature.is_empty() {
+            signed.signature[0] ^= 0xff;
+        }
+
+        let result = verify_manifest(&signed);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_with_wrong_public_key() {
+        let signer1 = Signer::generate();
+        let signer2 = Signer::generate();
+        let manifest = create_test_manifest();
+
+        let signed = sign_manifest(&manifest, &signer1);
+
+        // Try to verify with a different key
+        let result = verify_manifest_with_key(&signed, &signer2.verifying_key());
+        assert!(matches!(
+            result,
+            Err(ManifestSignerError::VerificationFailed(_))
+        ));
+    }
+
+    #[test]
+    fn test_verify_with_correct_public_key() {
+        let signer = Signer::generate();
+        let manifest = create_test_manifest();
+
+        let signed = sign_manifest(&manifest, &signer);
+        let verified = verify_manifest_with_key(&signed, &signer.verifying_key()).unwrap();
+
+        assert_eq!(manifest, verified);
+    }
+
+    #[test]
+    fn test_signed_manifest_serialization_roundtrip() {
+        let signer = Signer::generate();
+        let manifest = create_test_manifest();
+
+        let signed = sign_manifest(&manifest, &signer);
+        let json = serde_json::to_string(&signed).unwrap();
+        let deserialized: SignedManifest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(signed, deserialized);
+
+        // Verify the deserialized signed manifest is still valid
+        let verified = verify_manifest(&deserialized).unwrap();
+        assert_eq!(manifest, verified);
+    }
+
+    #[test]
+    fn test_signed_manifest_id_extraction() {
+        let signer = Signer::generate();
+        let manifest = create_test_manifest();
+
+        let signed = sign_manifest(&manifest, &signer);
+        let id = signed.manifest_id().unwrap();
+
+        assert_eq!(id, "manifest-001");
+    }
+
+    #[test]
+    fn test_deterministic_signing() {
+        // Ed25519 signatures are deterministic
+        let signer = Signer::generate();
+        let manifest = create_test_manifest();
+
+        let signed1 = sign_manifest(&manifest, &signer);
+        let signed2 = sign_manifest(&manifest, &signer);
+
+        assert_eq!(signed1.signature, signed2.signature);
+    }
+
+    #[test]
+    fn test_different_signers_produce_different_signatures() {
+        let signer1 = Signer::generate();
+        let signer2 = Signer::generate();
+        let manifest = create_test_manifest();
+
+        let signed1 = sign_manifest(&manifest, &signer1);
+        let signed2 = sign_manifest(&manifest, &signer2);
+
+        // Signatures should differ (different keys)
+        assert_ne!(signed1.signature, signed2.signature);
+        assert_ne!(signed1.public_key, signed2.public_key);
+
+        // Both should still verify
+        assert!(verify_manifest(&signed1).is_ok());
+        assert!(verify_manifest(&signed2).is_ok());
+    }
+
+    #[test]
+    fn test_public_key_in_signed_manifest() {
+        let signer = Signer::generate();
+        let manifest = create_test_manifest();
+
+        let signed = sign_manifest(&manifest, &signer);
+
+        // Public key should be hex-encoded
+        assert_eq!(signed.public_key.len(), 64); // 32 bytes = 64 hex chars
+        assert!(signed.public_key.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Should match the signer's public key
+        assert_eq!(signed.public_key, hex::encode(signer.public_key_bytes()));
+    }
+}


### PR DESCRIPTION
## Summary

Implements ticket TCK-00119 as part of the xtask development automation.

## Ticket

See `documents/work/tickets/TCK-00119.yaml` for requirements.

## Test Plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test -p xtask` passes
- [ ] Manual testing of the new command
