### PR TITLE
feat(TCK-00140): implement TargetProfile schema

### DIFF
--- a/crates/apm2-core/src/cac/mod.rs
+++ b/crates/apm2-core/src/cac/mod.rs
@@ -195,12 +195,12 @@ pub use pack_spec::{
 };
 pub use patch_engine::{PatchEngine, PatchEngineError, PatchResult, PatchType, ReplayViolation};
 pub use target_profile::{
-    BudgetPolicy, BudgetPolicyBuilder, DeliveryConstraints, DeliveryConstraintsBuilder,
-    OutputFormat, ProvenanceEmbed, RenderingPolicy, RenderingPolicyBuilder, RetrievalPolicy,
-    RetrievalPolicyBuilder, Stage, TargetProfile, TargetProfileBuilder, TargetProfileError,
-    DEFAULT_INLINE_THRESHOLD_BYTES, DEFAULT_MAX_CONTEXT_TOKENS, DEFAULT_MAX_FETCH_BYTES,
+    BudgetPolicy, BudgetPolicyBuilder, DEFAULT_INLINE_THRESHOLD_BYTES, DEFAULT_MAX_CONTEXT_TOKENS,
+    DEFAULT_MAX_FETCH_BYTES, DeliveryConstraints, DeliveryConstraintsBuilder,
     MAX_DESCRIPTION_LENGTH as TARGET_PROFILE_MAX_DESCRIPTION_LENGTH, MAX_FORMAT_HINT_LENGTH,
-    MAX_PROFILE_ID_LENGTH, MAX_VERSION_LENGTH,
+    MAX_PROFILE_ID_LENGTH, MAX_VERSION_LENGTH, OutputFormat, ProvenanceEmbed, RenderingPolicy,
+    RenderingPolicyBuilder, RetrievalPolicy, RetrievalPolicyBuilder, Stage, TargetProfile,
+    TargetProfileBuilder, TargetProfileError,
 };
 pub use validator::{
     CacValidator, MAX_ARRAY_MEMBERS, MAX_DEPTH, MAX_OBJECT_PROPERTIES, ValidationError,

--- a/crates/apm2-core/src/cac/target_profile.rs
+++ b/crates/apm2-core/src/cac/target_profile.rs
@@ -8,8 +8,8 @@
 //!
 //! - **Stage Taxonomy**: Profiles define rendering policies per stage
 //!   (plan/implement/review/ops) following DD-0005
-//! - **Typed Quantities**: Budget limits use explicit units to prevent
-//!   "Mars Climate Orbiter" errors (per DD-0007)
+//! - **Typed Quantities**: Budget limits use explicit units to prevent "Mars
+//!   Climate Orbiter" errors (per DD-0007)
 //! - **Strict Serde**: All types use `#[serde(deny_unknown_fields)]` to reject
 //!   unknown fields (CTR-1604)
 //! - **Forward Compatibility**: Enums use `#[non_exhaustive]` for safe
@@ -664,7 +664,9 @@ impl RetrievalPolicyBuilder {
     pub fn build(self) -> RetrievalPolicy {
         RetrievalPolicy {
             max_fetch_bytes: self.max_fetch_bytes.unwrap_or_else(default_max_fetch_bytes),
-            inline_threshold: self.inline_threshold.unwrap_or_else(default_inline_threshold),
+            inline_threshold: self
+                .inline_threshold
+                .unwrap_or_else(default_inline_threshold),
         }
     }
 }
@@ -881,7 +883,7 @@ fn is_valid_profile_id(id: &str) -> bool {
 
     let mut chars = id.chars();
     match chars.next() {
-        Some(c) if c.is_ascii_lowercase() => {}
+        Some(c) if c.is_ascii_lowercase() => {},
         _ => return false,
     }
 
@@ -958,12 +960,16 @@ impl TargetProfileBuilder {
     /// validation fails.
     pub fn build(self) -> Result<TargetProfile, TargetProfileError> {
         let profile = TargetProfile {
-            profile_id: self.profile_id.ok_or_else(|| TargetProfileError::MissingField {
-                field: "profile_id".to_string(),
-            })?,
-            version: self.version.ok_or_else(|| TargetProfileError::MissingField {
-                field: "version".to_string(),
-            })?,
+            profile_id: self
+                .profile_id
+                .ok_or_else(|| TargetProfileError::MissingField {
+                    field: "profile_id".to_string(),
+                })?,
+            version: self
+                .version
+                .ok_or_else(|| TargetProfileError::MissingField {
+                    field: "version".to_string(),
+                })?,
             description: self.description,
             rendering_policy: self.rendering_policy,
             budget_policy: self.budget_policy.unwrap_or_default(),
@@ -1194,7 +1200,10 @@ mod tests {
     fn test_retrieval_policy_default() {
         let policy = RetrievalPolicy::default();
         assert_eq!(policy.max_fetch_bytes.value(), DEFAULT_MAX_FETCH_BYTES);
-        assert_eq!(policy.inline_threshold.value(), DEFAULT_INLINE_THRESHOLD_BYTES);
+        assert_eq!(
+            policy.inline_threshold.value(),
+            DEFAULT_INLINE_THRESHOLD_BYTES
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `TargetProfile` struct with policies for CAC export pipeline configuration (DD-0005)
- Define stage taxonomy (plan/implement/review/ops) for rendering policies
- Implement typed quantities for budget limits preventing "Mars Climate Orbiter" errors (DD-0007)
- Use strict serde (`#[serde(deny_unknown_fields)]`) per CTR-1604 and `#[non_exhaustive]` on enums

## Test plan

- [x] All 40 unit tests pass: `cargo test target_profile`
- [x] Clippy passes with no warnings: `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Unknown fields rejected with clear serde errors
- [x] Builder validates all required fields and budget limit units

Generated with [Claude Code](https://claude.com/claude-code)