### PR TITLE
feat(TCK-00147): add CLI commands: capabilities and selftest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,6 +3211,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "apm2-core",
  "chrono",
  "clap",
  "directories",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -28,6 +28,7 @@ shell-words = { workspace = true }
 syn = { version = "2.0", features = ["full", "parsing"] }
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 strsim = "0.11"
+apm2-core = { workspace = true }
 
 [lints]
 workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -32,6 +32,10 @@
 //! - `aat <PR_URL> --dry-run` - Preview AAT without setting status
 //! - `lint` - Check for anti-patterns (`temp_dir`, shell interpolation)
 //! - `lint --fix` - Check for anti-patterns (fix flag placeholder)
+//! - `capabilities` - Generate capability manifest for the binary
+//! - `capabilities --json` - Output manifest in JSON format
+//! - `selftest` - Run CAC capability selftests
+//! - `selftest --filter <pattern>` - Run only matching tests
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -167,6 +171,24 @@ enum Commands {
     /// Findings are reported as warnings (not errors) to allow gradual
     /// adoption.
     Lint(tasks::lint::LintArgs),
+
+    /// Generate capability manifest for this binary.
+    ///
+    /// Introspects the CLI commands and generates a manifest describing
+    /// all available capabilities and their requirements.
+    ///
+    /// The manifest can be used for capability-based access control (CAC)
+    /// to verify that the binary supports required operations.
+    Capabilities(tasks::capabilities::CapabilitiesArgs),
+
+    /// Run CAC capability selftests.
+    ///
+    /// Executes the selftest suite to verify that advertised capabilities
+    /// actually work. Produces an AAT receipt that can be used to prove
+    /// capability compliance.
+    ///
+    /// Exit code is 0 if all tests pass, 1 if any test fails.
+    Selftest(tasks::selftest::SelftestArgs),
 }
 
 /// Security review exec subcommands.
@@ -273,5 +295,7 @@ fn main() -> Result<()> {
             ai_tool,
         } => tasks::aat(&pr_url, dry_run, ai_tool),
         Commands::Lint(args) => tasks::lint::run(args),
+        Commands::Capabilities(args) => tasks::capabilities::run(args),
+        Commands::Selftest(args) => tasks::selftest::run(&args),
     }
 }

--- a/xtask/src/tasks/capabilities.rs
+++ b/xtask/src/tasks/capabilities.rs
@@ -1,0 +1,483 @@
+//! Implementation of the `capabilities` command.
+//!
+//! This command generates a capability manifest for the current binary,
+//! describing all available CLI commands and their capabilities.
+//!
+//! # Output Formats
+//!
+//! - Human-readable (default): Pretty-printed summary
+//! - JSON (`--json`): Machine-readable capability manifest
+//!
+//! # Example
+//!
+//! ```bash
+//! # Human-readable output
+//! cargo xtask capabilities
+//!
+//! # JSON output
+//! cargo xtask capabilities --json
+//!
+//! # Write to file
+//! cargo xtask capabilities --json --output manifest.json
+//! ```
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use apm2_core::cac::manifest::{
+    Capability, CapabilityManifest, Command, ManifestConfig, VerificationMethod,
+};
+use clap::Parser;
+
+// ============================================================================
+// Arguments
+// ============================================================================
+
+/// Arguments for the capabilities command.
+#[derive(Parser, Debug, Clone)]
+pub struct CapabilitiesArgs {
+    /// Output in JSON format instead of human-readable.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Write output to a file instead of stdout.
+    ///
+    /// Uses atomic write (tempfile + rename) to ensure data integrity.
+    #[arg(long, short = 'o')]
+    pub output: Option<PathBuf>,
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+/// Runs the capabilities command.
+///
+/// Generates a capability manifest describing all CLI commands and
+/// capabilities.
+///
+/// # Arguments
+///
+/// * `args` - The capabilities command arguments
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Manifest generation fails
+/// - File output fails (when `--output` is specified)
+pub fn run(args: CapabilitiesArgs) -> Result<()> {
+    // Generate the manifest configuration from environment
+    let config = ManifestConfig::from_env();
+
+    // Generate base manifest
+    let mut manifest = CapabilityManifest::generate(&config);
+
+    // Populate commands from CLI structure
+    populate_commands(&mut manifest);
+
+    // Populate capabilities
+    populate_capabilities(&mut manifest);
+
+    // Format output
+    let output_content = if args.json {
+        manifest
+            .to_canonical_json()
+            .context("Failed to serialize manifest to JSON")?
+    } else {
+        format_human_readable(&manifest)
+    };
+
+    // Write output
+    if let Some(output_path) = args.output {
+        write_atomic(&output_path, &output_content)?;
+        println!("Capability manifest written to: {}", output_path.display());
+    } else {
+        println!("{output_content}");
+    }
+
+    Ok(())
+}
+
+/// Populates the manifest with CLI commands.
+fn populate_commands(manifest: &mut CapabilityManifest) {
+    // Main xtask commands
+    let commands = vec![
+        Command::builder()
+            .name("start-ticket")
+            .description("Start work on the next unblocked ticket")
+            .build()
+            .expect("valid command"),
+        Command::builder()
+            .name("commit")
+            .description("Run checks and create a commit")
+            .build()
+            .expect("valid command"),
+        Command::builder()
+            .name("push")
+            .description("Push branch and create PR with AI reviews")
+            .build()
+            .expect("valid command"),
+        Command::builder()
+            .name("check")
+            .description("Show ticket and PR status")
+            .build()
+            .expect("valid command"),
+        Command::builder()
+            .name("finish")
+            .description("Clean up after PR merge")
+            .build()
+            .expect("valid command"),
+        Command::builder()
+            .name("review")
+            .description("Run AI reviews for a PR")
+            .subcommand(
+                Command::builder()
+                    .name("security")
+                    .description("Run security review")
+                    .build()
+                    .expect("valid command"),
+            )
+            .subcommand(
+                Command::builder()
+                    .name("quality")
+                    .description("Run code quality review")
+                    .build()
+                    .expect("valid command"),
+            )
+            .subcommand(
+                Command::builder()
+                    .name("uat")
+                    .description("Run UAT sign-off")
+                    .build()
+                    .expect("valid command"),
+            )
+            .build()
+            .expect("valid command"),
+        Command::builder()
+            .name("security-review-exec")
+            .description("Security review execution commands")
+            .subcommand(
+                Command::builder()
+                    .name("approve")
+                    .description("Approve PR after security review")
+                    .build()
+                    .expect("valid command"),
+            )
+            .subcommand(
+                Command::builder()
+                    .name("deny")
+                    .description("Deny PR with reason")
+                    .build()
+                    .expect("valid command"),
+            )
+            .subcommand(
+                Command::builder()
+                    .name("onboard")
+                    .description("Show required reading for reviewers")
+                    .build()
+                    .expect("valid command"),
+            )
+            .build()
+            .expect("valid command"),
+        Command::builder()
+            .name("aat")
+            .description("Run Agent Acceptance Testing on a PR")
+            .build()
+            .expect("valid command"),
+        Command::builder()
+            .name("lint")
+            .description("Check for anti-patterns in the codebase")
+            .build()
+            .expect("valid command"),
+        Command::builder()
+            .name("capabilities")
+            .description("Generate capability manifest for this binary")
+            .build()
+            .expect("valid command"),
+        Command::builder()
+            .name("selftest")
+            .description("Run CAC capability selftests")
+            .build()
+            .expect("valid command"),
+    ];
+
+    for cmd in commands {
+        manifest.add_command(cmd);
+    }
+}
+
+/// Populates the manifest with capabilities.
+fn populate_capabilities(manifest: &mut CapabilityManifest) {
+    let capabilities = vec![
+        Capability::builder()
+            .id("cac:patch:apply")
+            .description("Apply JSON patches to CAC artifacts with replay protection")
+            .verification_method(VerificationMethod::Selftest)
+            .selftest_id("test_patch_apply_valid")
+            .build()
+            .expect("valid capability"),
+        Capability::builder()
+            .id("cac:admission:validate")
+            .description("Validate artifacts through admission pipeline")
+            .verification_method(VerificationMethod::Selftest)
+            .selftest_id("test_admission_valid_artifact")
+            .build()
+            .expect("valid capability"),
+        Capability::builder()
+            .id("cac:manifest:generate")
+            .description("Generate capability manifests with binary hash binding")
+            .verification_method(VerificationMethod::Selftest)
+            .selftest_id("test_manifest_deterministic")
+            .build()
+            .expect("valid capability"),
+        Capability::builder()
+            .id("cac:receipt:sign")
+            .description("Sign AAT receipts with Ed25519")
+            .verification_method(VerificationMethod::Selftest)
+            .selftest_id("test_receipt_sign_verify")
+            .build()
+            .expect("valid capability"),
+        Capability::builder()
+            .id("aat:hypothesis:execute")
+            .description("Execute hypothesis-driven tests")
+            .verification_method(VerificationMethod::Declared)
+            .build()
+            .expect("valid capability"),
+        Capability::builder()
+            .id("aat:evidence:bundle")
+            .description("Generate evidence bundles from test execution")
+            .verification_method(VerificationMethod::Declared)
+            .build()
+            .expect("valid capability"),
+    ];
+
+    for cap in capabilities {
+        // Add selftest ref if applicable (before moving cap)
+        if cap.verification_method == VerificationMethod::Selftest {
+            if let Some(selftest_id) = &cap.selftest_id {
+                manifest.add_selftest_ref(selftest_id, &cap.id);
+            }
+        }
+        manifest.add_capability(cap);
+    }
+}
+
+/// Formats the manifest as human-readable text.
+fn format_human_readable(manifest: &CapabilityManifest) -> String {
+    use std::fmt::Write;
+    let sorted = manifest.to_sorted();
+
+    let mut output = String::new();
+
+    output.push_str("=== Capability Manifest ===\n\n");
+
+    let _ = writeln!(output, "Version:     {}", sorted.version);
+    let _ = writeln!(output, "Target:      {}", sorted.target);
+    let _ = writeln!(output, "Profile:     {}", sorted.profile);
+    let _ = writeln!(output, "Binary Hash: {}", sorted.binary_hash);
+    let _ = writeln!(output, "Schema:      {}", sorted.schema_version);
+
+    output.push_str("\n--- Commands ---\n\n");
+    for cmd in &sorted.commands {
+        format_command(&mut output, cmd, 0);
+    }
+
+    output.push_str("\n--- Capabilities ---\n\n");
+    for cap in &sorted.capabilities {
+        let _ = writeln!(
+            output,
+            "  {} [{}]",
+            cap.id,
+            cap.verification_method.as_str()
+        );
+        if let Some(desc) = &cap.description {
+            let _ = writeln!(output, "    {desc}");
+        }
+        if let Some(selftest) = &cap.selftest_id {
+            let _ = writeln!(output, "    Selftest: {selftest}");
+        }
+    }
+
+    let _ = writeln!(
+        output,
+        "\nTotal: {} commands, {} capabilities",
+        count_commands(&sorted.commands),
+        sorted.capabilities.len()
+    );
+
+    output
+}
+
+/// Formats a single command with indentation.
+fn format_command(output: &mut String, cmd: &Command, depth: usize) {
+    use std::fmt::Write;
+    let indent = "  ".repeat(depth + 1);
+    let _ = write!(output, "{indent}{}", cmd.name);
+    if let Some(desc) = &cmd.description {
+        let _ = write!(output, " - {desc}");
+    }
+    output.push('\n');
+
+    for subcmd in &cmd.subcommands {
+        format_command(output, subcmd, depth + 1);
+    }
+}
+
+/// Counts total commands including subcommands.
+fn count_commands(commands: &[Command]) -> usize {
+    commands
+        .iter()
+        .map(|c| 1 + count_commands(&c.subcommands))
+        .sum()
+}
+
+/// Writes content to a file atomically using tempfile + rename.
+///
+/// This follows CTR-2607: State Files Use Atomic Write.
+fn write_atomic(path: &PathBuf, content: &str) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+
+    // Create a tempfile in the same directory for atomic rename
+    let mut temp_file =
+        tempfile::NamedTempFile::new_in(parent).context("Failed to create temp file")?;
+
+    temp_file
+        .write_all(content.as_bytes())
+        .context("Failed to write to temp file")?;
+
+    temp_file
+        .persist(path)
+        .context("Failed to persist temp file")?;
+
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capabilities_args_default() {
+        let args = CapabilitiesArgs {
+            json: false,
+            output: None,
+        };
+        assert!(!args.json);
+        assert!(args.output.is_none());
+    }
+
+    #[test]
+    fn test_capabilities_args_json() {
+        let args = CapabilitiesArgs {
+            json: true,
+            output: None,
+        };
+        assert!(args.json);
+    }
+
+    #[test]
+    fn test_capabilities_args_output() {
+        let args = CapabilitiesArgs {
+            json: true,
+            output: Some(PathBuf::from("manifest.json")),
+        };
+        assert_eq!(args.output, Some(PathBuf::from("manifest.json")));
+    }
+
+    #[test]
+    fn test_populate_commands() {
+        let config = ManifestConfig::builder()
+            .version("0.1.0")
+            .target("x86_64-unknown-linux-gnu")
+            .profile("debug")
+            .build()
+            .unwrap();
+
+        let mut manifest = CapabilityManifest::generate(&config);
+        populate_commands(&mut manifest);
+
+        assert!(!manifest.commands.is_empty());
+
+        // Check for expected commands
+        let cmd_names: Vec<&str> = manifest.commands.iter().map(|c| c.name.as_str()).collect();
+        assert!(cmd_names.contains(&"capabilities"));
+        assert!(cmd_names.contains(&"selftest"));
+        assert!(cmd_names.contains(&"lint"));
+    }
+
+    #[test]
+    fn test_populate_capabilities() {
+        let config = ManifestConfig::builder()
+            .version("0.1.0")
+            .target("x86_64-unknown-linux-gnu")
+            .profile("debug")
+            .build()
+            .unwrap();
+
+        let mut manifest = CapabilityManifest::generate(&config);
+        populate_capabilities(&mut manifest);
+
+        assert!(!manifest.capabilities.is_empty());
+
+        // Check for expected capabilities
+        let cap_ids: Vec<&str> = manifest
+            .capabilities
+            .iter()
+            .map(|c| c.id.as_str())
+            .collect();
+        assert!(cap_ids.contains(&"cac:patch:apply"));
+        assert!(cap_ids.contains(&"cac:admission:validate"));
+    }
+
+    #[test]
+    fn test_format_human_readable() {
+        let config = ManifestConfig::builder()
+            .version("0.1.0")
+            .target("x86_64-unknown-linux-gnu")
+            .profile("debug")
+            .build()
+            .unwrap();
+
+        let mut manifest = CapabilityManifest::generate(&config);
+        populate_commands(&mut manifest);
+        populate_capabilities(&mut manifest);
+
+        let output = format_human_readable(&manifest);
+
+        assert!(output.contains("Capability Manifest"));
+        assert!(output.contains("Version:"));
+        assert!(output.contains("Commands"));
+        assert!(output.contains("Capabilities"));
+    }
+
+    #[test]
+    fn test_count_commands() {
+        let commands = vec![
+            Command::builder().name("simple").build().unwrap(),
+            Command::builder()
+                .name("parent")
+                .subcommand(Command::builder().name("child1").build().unwrap())
+                .subcommand(Command::builder().name("child2").build().unwrap())
+                .build()
+                .unwrap(),
+        ];
+
+        assert_eq!(count_commands(&commands), 4);
+    }
+
+    #[test]
+    fn test_write_atomic() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("test_output.txt");
+
+        write_atomic(&path, "test content").unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "test content");
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -5,6 +5,7 @@
 //! ones.
 
 mod aat;
+pub mod capabilities;
 mod check;
 mod commit;
 mod finish;
@@ -12,6 +13,7 @@ pub mod lint;
 mod push;
 mod review;
 mod security_review_exec;
+pub mod selftest;
 mod start_ticket;
 
 use anyhow::Result;

--- a/xtask/src/tasks/selftest.rs
+++ b/xtask/src/tasks/selftest.rs
@@ -1,0 +1,447 @@
+//! Implementation of the `selftest` command.
+//!
+//! This command runs CAC capability selftests to verify that advertised
+//! capabilities actually work. It produces an AAT receipt that can be used
+//! to prove capability compliance.
+//!
+//! # Exit Codes
+//!
+//! - 0: All tests passed
+//! - 1: One or more tests failed
+//!
+//! # Output Formats
+//!
+//! - Human-readable (default): Summary with pass/fail counts
+//! - JSON (`--json`): Full execution results
+//!
+//! # Example
+//!
+//! ```bash
+//! # Run all selftests
+//! cargo xtask selftest
+//!
+//! # Run only patch-related tests
+//! cargo xtask selftest --filter patch
+//!
+//! # JSON output to file
+//! cargo xtask selftest --json --output receipt.json
+//!
+//! # With custom timeout
+//! cargo xtask selftest --timeout 300
+//! ```
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use crate::aat::cac_harness::{BudgetConstraints, CacSelftestSuite, SuiteExecutionResult};
+
+// ============================================================================
+// Arguments
+// ============================================================================
+
+/// Arguments for the selftest command.
+#[derive(Parser, Debug, Clone)]
+pub struct SelftestArgs {
+    /// Output in JSON format instead of human-readable.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Filter tests by name pattern.
+    ///
+    /// Only tests whose capability ID or test name contains this pattern
+    /// will be executed. Matching is case-insensitive.
+    #[arg(long, short = 'f')]
+    pub filter: Option<String>,
+
+    /// Write output to a file instead of stdout.
+    ///
+    /// Uses atomic write (tempfile + rename) to ensure data integrity.
+    #[arg(long, short = 'o')]
+    pub output: Option<PathBuf>,
+
+    /// Timeout in seconds for each test (default: 120).
+    #[arg(long, short = 't', default_value = "120")]
+    pub timeout: u64,
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+/// Runs the selftest command.
+///
+/// Discovers and executes CAC capability selftests, producing results that
+/// can verify capability compliance.
+///
+/// # Arguments
+///
+/// * `args` - The selftest command arguments
+///
+/// # Returns
+///
+/// Returns `Ok(())` but may call `std::process::exit()` with:
+/// - 0: All tests passed
+/// - 1: One or more tests failed
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Test discovery fails
+/// - File output fails (when `--output` is specified)
+pub fn run(args: &SelftestArgs) -> Result<()> {
+    // Configure budget constraints
+    let budget = BudgetConstraints::builder()
+        .max_duration(Duration::from_secs(args.timeout))
+        .build();
+
+    // Discover tests
+    let mut suite = CacSelftestSuite::discover();
+    suite.set_budget(budget);
+
+    // Apply filter if specified
+    let tests_to_run: Vec<_> = args.filter.as_ref().map_or_else(
+        || suite.iter().cloned().collect(),
+        |pattern| {
+            let pattern_lower = pattern.to_lowercase();
+            suite
+                .iter()
+                .filter(|t| {
+                    t.capability_id.to_lowercase().contains(&pattern_lower)
+                        || t.test_name.to_lowercase().contains(&pattern_lower)
+                })
+                .cloned()
+                .collect()
+        },
+    );
+
+    // Check if we have tests to run
+    if tests_to_run.is_empty() {
+        let message = if args.filter.is_some() {
+            "No tests match the specified filter"
+        } else {
+            "No selftests discovered"
+        };
+
+        if args.json {
+            let empty_result = SuiteExecutionResult {
+                tests_passed: 0,
+                tests_failed: 0,
+                total_tests: 0,
+                results: vec![],
+                total_budget_consumed: crate::aat::cac_harness::BudgetConsumed::default(),
+                completed_at: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+            };
+            let output = serde_json::to_string_pretty(&empty_result)
+                .context("Failed to serialize empty result")?;
+            output_result(args, &output)?;
+        } else {
+            println!("{message}");
+        }
+        return Ok(());
+    }
+
+    // Create a new suite with only filtered tests
+    let mut filtered_suite = CacSelftestSuite::with_budget(suite.budget().clone());
+    for test in tests_to_run {
+        filtered_suite.add_test(test);
+    }
+
+    // Print header in human-readable mode
+    if !args.json {
+        println!("Running {} selftest(s)...\n", filtered_suite.len());
+    }
+
+    // Execute the tests
+    let result = filtered_suite
+        .execute()
+        .context("Failed to execute selftest suite")?;
+
+    // Format and output results
+    let output_content = if args.json {
+        serde_json::to_string_pretty(&result).context("Failed to serialize results to JSON")?
+    } else {
+        format_human_readable(&result)
+    };
+
+    output_result(args, &output_content)?;
+
+    // Exit with appropriate code
+    if result.all_passed() {
+        Ok(())
+    } else {
+        std::process::exit(1);
+    }
+}
+
+/// Formats the execution result as human-readable text.
+fn format_human_readable(result: &SuiteExecutionResult) -> String {
+    use std::fmt::Write;
+    let mut output = String::new();
+
+    // Individual test results
+    output.push_str("=== Test Results ===\n\n");
+
+    for test_result in &result.results {
+        let status = if test_result.passed { "PASS" } else { "FAIL" };
+        let status_color = if test_result.passed {
+            "\x1b[32m" // Green
+        } else {
+            "\x1b[31m" // Red
+        };
+        let reset = "\x1b[0m";
+
+        let _ = writeln!(
+            output,
+            "[{status_color}{status}{reset}] {}",
+            test_result.test_id
+        );
+
+        // Show error details for failed tests
+        if !test_result.passed {
+            if let Some(ref error) = test_result.error {
+                let _ = writeln!(output, "      Error: {error}");
+            }
+            if let Some(ref evidence) = test_result.evidence {
+                if !evidence.stderr.is_empty() {
+                    // Truncate long stderr
+                    let stderr_preview = if evidence.stderr.len() > 200 {
+                        format!("{}...", &evidence.stderr[..200])
+                    } else {
+                        evidence.stderr.clone()
+                    };
+                    let _ = writeln!(output, "      Stderr: {stderr_preview}");
+                }
+            }
+        }
+    }
+
+    // Summary
+    output.push_str("\n=== Summary ===\n\n");
+
+    let pass_indicator = if result.all_passed() {
+        "\x1b[32mALL PASSED\x1b[0m"
+    } else {
+        "\x1b[31mFAILED\x1b[0m"
+    };
+
+    let _ = writeln!(output, "Status: {pass_indicator}");
+    let _ = writeln!(output, "Passed: {}", result.tests_passed);
+    let _ = writeln!(output, "Failed: {}", result.tests_failed);
+    let _ = writeln!(output, "Total:  {}", result.total_tests);
+    let _ = writeln!(output, "Pass Rate: {:.1}%", result.pass_rate());
+    let _ = writeln!(
+        output,
+        "Duration: {:.2}s",
+        result.total_budget_consumed.duration.as_secs_f64()
+    );
+
+    // List failed tests
+    if result.tests_failed > 0 {
+        output.push_str("\nFailed tests:\n");
+        for test_id in result.failed_tests() {
+            let _ = writeln!(output, "  - {test_id}");
+        }
+    }
+
+    output
+}
+
+/// Outputs the result to stdout or file.
+fn output_result(args: &SelftestArgs, content: &str) -> Result<()> {
+    if let Some(ref output_path) = args.output {
+        write_atomic(output_path, content)?;
+        println!("Results written to: {}", output_path.display());
+    } else {
+        println!("{content}");
+    }
+    Ok(())
+}
+
+/// Writes content to a file atomically using tempfile + rename.
+///
+/// This follows CTR-2607: State Files Use Atomic Write.
+fn write_atomic(path: &PathBuf, content: &str) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+
+    // Create a tempfile in the same directory for atomic rename
+    let mut temp_file =
+        tempfile::NamedTempFile::new_in(parent).context("Failed to create temp file")?;
+
+    temp_file
+        .write_all(content.as_bytes())
+        .context("Failed to write to temp file")?;
+
+    temp_file
+        .persist(path)
+        .context("Failed to persist temp file")?;
+
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_selftest_args_default() {
+        let args = SelftestArgs {
+            json: false,
+            filter: None,
+            output: None,
+            timeout: 120,
+        };
+        assert!(!args.json);
+        assert!(args.filter.is_none());
+        assert!(args.output.is_none());
+        assert_eq!(args.timeout, 120);
+    }
+
+    #[test]
+    fn test_selftest_args_json() {
+        let args = SelftestArgs {
+            json: true,
+            filter: None,
+            output: None,
+            timeout: 120,
+        };
+        assert!(args.json);
+    }
+
+    #[test]
+    fn test_selftest_args_filter() {
+        let args = SelftestArgs {
+            json: false,
+            filter: Some("patch".to_string()),
+            output: None,
+            timeout: 120,
+        };
+        assert_eq!(args.filter, Some("patch".to_string()));
+    }
+
+    #[test]
+    fn test_selftest_args_output() {
+        let args = SelftestArgs {
+            json: true,
+            filter: None,
+            output: Some(PathBuf::from("results.json")),
+            timeout: 120,
+        };
+        assert_eq!(args.output, Some(PathBuf::from("results.json")));
+    }
+
+    #[test]
+    fn test_selftest_args_timeout() {
+        let args = SelftestArgs {
+            json: false,
+            filter: None,
+            output: None,
+            timeout: 300,
+        };
+        assert_eq!(args.timeout, 300);
+    }
+
+    #[test]
+    fn test_format_human_readable_all_passed() {
+        let result = SuiteExecutionResult {
+            tests_passed: 3,
+            tests_failed: 0,
+            total_tests: 3,
+            results: vec![
+                crate::aat::cac_harness::TestExecutionResult {
+                    test_id: "test1".to_string(),
+                    passed: true,
+                    evidence: None,
+                    error: None,
+                    budget_consumed: crate::aat::cac_harness::BudgetConsumed::default(),
+                },
+                crate::aat::cac_harness::TestExecutionResult {
+                    test_id: "test2".to_string(),
+                    passed: true,
+                    evidence: None,
+                    error: None,
+                    budget_consumed: crate::aat::cac_harness::BudgetConsumed::default(),
+                },
+                crate::aat::cac_harness::TestExecutionResult {
+                    test_id: "test3".to_string(),
+                    passed: true,
+                    evidence: None,
+                    error: None,
+                    budget_consumed: crate::aat::cac_harness::BudgetConsumed::default(),
+                },
+            ],
+            total_budget_consumed: crate::aat::cac_harness::BudgetConsumed::default(),
+            completed_at: "2026-01-27T12:00:00Z".to_string(),
+        };
+
+        let output = format_human_readable(&result);
+
+        assert!(output.contains("PASS"));
+        assert!(output.contains("Passed: 3"));
+        assert!(output.contains("Failed: 0"));
+        assert!(output.contains("ALL PASSED"));
+    }
+
+    #[test]
+    fn test_format_human_readable_some_failed() {
+        let result = SuiteExecutionResult {
+            tests_passed: 2,
+            tests_failed: 1,
+            total_tests: 3,
+            results: vec![
+                crate::aat::cac_harness::TestExecutionResult {
+                    test_id: "test1".to_string(),
+                    passed: true,
+                    evidence: None,
+                    error: None,
+                    budget_consumed: crate::aat::cac_harness::BudgetConsumed::default(),
+                },
+                crate::aat::cac_harness::TestExecutionResult {
+                    test_id: "test2".to_string(),
+                    passed: false,
+                    evidence: None,
+                    error: Some(crate::aat::cac_harness::CacHarnessError::ExecutionFailed {
+                        test_name: "test2".to_string(),
+                        message: "Test failed".to_string(),
+                    }),
+                    budget_consumed: crate::aat::cac_harness::BudgetConsumed::default(),
+                },
+                crate::aat::cac_harness::TestExecutionResult {
+                    test_id: "test3".to_string(),
+                    passed: true,
+                    evidence: None,
+                    error: None,
+                    budget_consumed: crate::aat::cac_harness::BudgetConsumed::default(),
+                },
+            ],
+            total_budget_consumed: crate::aat::cac_harness::BudgetConsumed::default(),
+            completed_at: "2026-01-27T12:00:00Z".to_string(),
+        };
+
+        let output = format_human_readable(&result);
+
+        assert!(output.contains("FAIL"));
+        assert!(output.contains("Passed: 2"));
+        assert!(output.contains("Failed: 1"));
+        assert!(output.contains("FAILED"));
+        assert!(output.contains("test2"));
+    }
+
+    #[test]
+    fn test_write_atomic() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("test_output.txt");
+
+        write_atomic(&path, "test content").unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "test content");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `cargo xtask capabilities` command for generating capability manifests with human-readable and JSON output formats
- Add `cargo xtask selftest` command for running CAC capability selftests with filtering and timeout options
- Both commands support --output flag for atomic file writes and integrate with existing CapabilityManifest (TCK-00144) and CacSelftestSuite (TCK-00145)

## Test plan
- [x] `cargo xtask capabilities` outputs human-readable manifest
- [x] `cargo xtask capabilities --json` outputs JSON format
- [x] `cargo xtask capabilities --output /tmp/manifest.json` writes to file
- [x] `cargo xtask selftest` runs all selftests and reports results
- [x] `cargo xtask selftest --filter manifest` runs only matching tests
- [x] `cargo xtask selftest --json` outputs JSON format
- [x] Exit code 0 when all tests pass, 1 when any fail
- [x] `cargo test -p xtask` passes (476 tests)
- [x] `cargo clippy -p xtask` passes with no warnings

Generated with [Claude Code](https://claude.com/claude-code)