### PR TITLE
feat(TCK-00166): implement tool receipt generation

### DIFF
--- a/crates/apm2-daemon/src/evidence/binding.rs
+++ b/crates/apm2-daemon/src/evidence/binding.rs
@@ -144,8 +144,11 @@ impl EvidenceBinding {
     /// Returns an error if adding the reference would exceed
     /// `MAX_EVIDENCE_REFS`.
     pub fn add_evidence_ref(&mut self, hash: Hash) -> Result<(), ReceiptError> {
-        // Count total refs (args + result + additional)
-        let total = self.evidence_refs().len() + 1;
+        // Count total refs (args + result + additional) without allocation
+        // Using O(1) computation instead of calling evidence_refs() which is O(n)
+        let args_count = usize::from(self.args_hash.is_some());
+        let result_count = usize::from(self.result_hash.is_some());
+        let total = args_count + result_count + self.additional_refs.len() + 1;
         if total > MAX_EVIDENCE_REFS {
             return Err(ReceiptError::TooManyEvidenceRefs {
                 count: total,

--- a/crates/apm2-daemon/src/evidence/mod.rs
+++ b/crates/apm2-daemon/src/evidence/mod.rs
@@ -38,9 +38,10 @@ pub mod receipt_builder;
 // Re-export binding types
 pub use binding::{EvidenceBinding, ToolEvidenceCollector};
 pub use receipt::{
-    CanonicalizerId, Hash, MAX_CANONICALIZER_ID_LEN, MAX_CAPABILITY_ID_LEN, MAX_EPISODE_ID_LEN,
-    MAX_EVIDENCE_REFS, MAX_REQUEST_ID_LEN, MAX_RESULT_MESSAGE_LEN, MAX_SIGNER_IDENTITY_LEN,
-    ReceiptError, ReceiptKind, Signature, SignerIdentity, ToolExecutionDetails, ToolReceipt,
+    CanonicalizerId, EpisodeId, Hash, MAX_CANONICALIZER_ID_LEN, MAX_CAPABILITY_ID_LEN,
+    MAX_EPISODE_ID_LEN, MAX_EVIDENCE_REFS, MAX_REQUEST_ID_LEN, MAX_RESULT_MESSAGE_LEN,
+    MAX_SIGNER_IDENTITY_LEN, ReceiptError, ReceiptKind, Signature, SignerIdentity,
+    ToolExecutionDetails, ToolReceipt,
 };
 // Re-export builder
 pub use receipt_builder::{ReceiptBuilder, ReceiptSigning};


### PR DESCRIPTION
## Summary

- Implements tool receipt generation system per RFC-0013 and AD-RECEIPT-001
- Adds `ToolReceipt` struct with envelope_hash, policy_hash, evidence_refs, and optional signature
- Adds `ReceiptKind` enum for ToolExecution, EpisodeStart, EpisodeStop, EpisodeQuarantine, BudgetCheckpoint, PolicyEvaluation
- Adds `ReceiptBuilder` with builder pattern for constructing unsigned receipts
- Adds `EvidenceBinding` and `ToolEvidenceCollector` for CAS hash collection
- Implements `canonical_bytes()` per AD-VERIFY-001 (excludes signature, sorts evidence_refs)
- Adds comprehensive unit tests and golden vector tests for hash stability

## Contract References

- AD-RECEIPT-001: Tool receipt generation
- AD-VERIFY-001: Deterministic protobuf serialization
- CTR-1303: Bounded collections with MAX_* constants
- CTR-1604: `deny_unknown_fields` on ledger/audit types
- CTR-1205/CTR-2603: Builder validates ALL inputs

## Test Plan

- [x] All 61 evidence module unit tests pass
- [x] Golden vector tests verify canonical bytes determinism
- [x] Clippy passes with -D warnings
- [x] cargo fmt applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)