### PR TITLE
feat(TCK-00169): implement TelemetryCollector and frame streaming

### DIFF
--- a/crates/apm2-daemon/src/telemetry/collector.rs
+++ b/crates/apm2-daemon/src/telemetry/collector.rs
@@ -1,0 +1,706 @@
+//! `TelemetryCollector` implementation for frame streaming.
+//!
+//! This module implements the `TelemetryCollector` per CTR-DAEMON-005,
+//! providing periodic resource metric collection with ring buffer storage
+//! and budget integration.
+//!
+//! # Architecture
+//!
+//! ```text
+//! TelemetryCollector
+//!     |
+//!     +-- start(episode_id, pid) --> TelemetryHandle
+//!     |
+//!     +-- collect(handle) --> TelemetryFrame
+//!     |
+//!     +-- apply_policy(policy) --> updates collection parameters
+//!     |
+//!     +-- spawn_collection_loop() --> async task for periodic collection
+//! ```
+//!
+//! # Collection Loop
+//!
+//! The collector spawns an async task that:
+//! 1. Sleeps for `sample_interval`
+//! 2. Reads metrics from `CgroupReader`
+//! 3. Computes deltas from previous sample
+//! 4. Pushes frame to ring buffer
+//! 5. Reports consumption to `BudgetTracker`
+//!
+//! # Budget Integration
+//!
+//! Per CTR-DAEMON-005, the collector integrates with budget accounting:
+//! - Reports `cpu_ms` from telemetry to budget tracker
+//! - Reports `bytes_io` from telemetry to budget tracker
+//! - Checks limits and triggers stop if exhausted
+//!
+//! # Contract References
+//!
+//! - CTR-DAEMON-005: `TelemetryCollector` and frame streaming
+
+use std::sync::Arc;
+
+use nix::unistd::Pid;
+use thiserror::Error;
+use tokio::sync::mpsc;
+use tokio::time::{Duration, sleep};
+use tracing::{debug, warn};
+
+use super::cgroup::CgroupReader;
+use super::frame::{O11yFlags, TelemetryFrame};
+use super::handle::TelemetryHandle;
+use super::policy::TelemetryPolicy;
+use crate::episode::{BudgetDelta, BudgetExhaustedError, BudgetTracker, EpisodeId};
+
+/// Error type for telemetry collection operations.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum TelemetryError {
+    /// Collection is stopped.
+    #[error("telemetry collection is stopped for episode {episode_id}")]
+    Stopped {
+        /// Episode identifier.
+        episode_id: String,
+    },
+
+    /// Budget exhausted during collection.
+    #[error("budget exhausted during telemetry collection: {source}")]
+    BudgetExhausted {
+        /// The budget exhaustion error.
+        #[source]
+        source: BudgetExhaustedError,
+    },
+
+    /// Cgroup reader failed.
+    #[error("cgroup reader unavailable for episode {episode_id}")]
+    CgroupUnavailable {
+        /// Episode identifier.
+        episode_id: String,
+    },
+
+    /// Invalid configuration.
+    #[error("invalid telemetry configuration: {reason}")]
+    InvalidConfig {
+        /// Reason for the error.
+        reason: String,
+    },
+}
+
+/// Result type for telemetry operations.
+pub type TelemetryResult<T> = Result<T, TelemetryError>;
+
+/// Telemetry collector for episode resource monitoring.
+///
+/// Per CTR-DAEMON-005, this collector:
+/// - Collects resource metrics at configurable intervals
+/// - Stores frames in a ring buffer
+/// - Reports consumption to budget tracker
+/// - Supports high-frequency mode when budget nearing exhaustion
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use apm2_daemon::telemetry::{TelemetryCollector, TelemetryPolicy};
+/// use apm2_daemon::episode::EpisodeId;
+/// use nix::unistd::Pid;
+///
+/// let collector = TelemetryCollector::new(TelemetryPolicy::default());
+/// let handle = collector.start(
+///     EpisodeId::new("ep-001")?,
+///     Pid::from_raw(1234),
+/// )?;
+///
+/// // Collection happens asynchronously...
+///
+/// // Get current frame manually
+/// let frame = collector.collect(&handle)?;
+///
+/// // Stop collection
+/// let frames = handle.stop();
+/// ```
+#[derive(Debug)]
+pub struct TelemetryCollector {
+    /// Collection policy.
+    policy: TelemetryPolicy,
+}
+
+impl TelemetryCollector {
+    /// Creates a new telemetry collector with the given policy.
+    #[must_use]
+    pub const fn new(policy: TelemetryPolicy) -> Self {
+        Self { policy }
+    }
+
+    /// Creates a new telemetry collector with default policy.
+    #[must_use]
+    pub fn with_default_policy() -> Self {
+        Self::new(TelemetryPolicy::default())
+    }
+
+    /// Returns the current policy.
+    #[must_use]
+    pub const fn policy(&self) -> &TelemetryPolicy {
+        &self.policy
+    }
+
+    /// Applies a new policy.
+    ///
+    /// Note: This only affects new collection sessions. Existing handles
+    /// continue with their original policy.
+    pub const fn apply_policy(&mut self, policy: TelemetryPolicy) {
+        self.policy = policy;
+    }
+
+    /// Starts telemetry collection for an episode.
+    ///
+    /// # Arguments
+    ///
+    /// * `episode_id` - Episode identifier
+    /// * `pid` - Process ID to monitor
+    ///
+    /// # Returns
+    ///
+    /// A handle for the active collection session.
+    #[must_use]
+    pub fn start(&self, episode_id: EpisodeId, pid: Pid) -> TelemetryHandle {
+        TelemetryHandle::new(episode_id, pid, self.policy.ring_buffer_capacity())
+    }
+
+    /// Collects a single telemetry frame.
+    ///
+    /// This manually collects a frame using the provided cgroup reader.
+    /// For automatic periodic collection, use `spawn_collection_loop`.
+    ///
+    /// # Arguments
+    ///
+    /// * `handle` - Active collection handle
+    /// * `reader` - Cgroup reader for metrics
+    /// * `o11y_flags` - Observability flags for this frame
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if collection is stopped.
+    pub fn collect(
+        &self,
+        handle: &TelemetryHandle,
+        reader: &CgroupReader,
+        o11y_flags: O11yFlags,
+    ) -> TelemetryResult<TelemetryFrame> {
+        if handle.is_stopped() {
+            return Err(TelemetryError::Stopped {
+                episode_id: handle.episode_id().to_string(),
+            });
+        }
+
+        // Read current stats
+        let stats = reader.read_all();
+
+        // Create frame
+        handle
+            .next_frame(stats, o11y_flags)
+            .ok_or_else(|| TelemetryError::Stopped {
+                episode_id: handle.episode_id().to_string(),
+            })
+    }
+
+    /// Collects a frame and reports consumption to the budget tracker.
+    ///
+    /// # Arguments
+    ///
+    /// * `handle` - Active collection handle
+    /// * `reader` - Cgroup reader for metrics
+    /// * `budget_tracker` - Budget tracker for consumption reporting
+    /// * `o11y_flags` - Observability flags for this frame
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(Some(frame))` if collection succeeded.
+    /// Returns `Ok(None)` if budget is exhausted (caller should stop episode).
+    /// Returns `Err` if collection failed for other reasons.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if collection is stopped.
+    pub fn collect_with_budget(
+        &self,
+        handle: &TelemetryHandle,
+        reader: &CgroupReader,
+        budget_tracker: &BudgetTracker,
+        o11y_flags: O11yFlags,
+    ) -> TelemetryResult<Option<TelemetryFrame>> {
+        if handle.is_stopped() {
+            return Err(TelemetryError::Stopped {
+                episode_id: handle.episode_id().to_string(),
+            });
+        }
+
+        // Read current stats
+        let stats = reader.read_all();
+
+        // Compute delta from previous
+        let (cpu_delta_ns, io_delta_bytes) = handle.compute_delta(&stats);
+
+        // Convert nanoseconds to milliseconds for budget
+        let budget_delta = BudgetDelta {
+            tokens: 0,
+            tool_calls: 0,
+            wall_ms: 0,
+            cpu_ms: cpu_delta_ns / 1_000_000,
+            bytes_io: io_delta_bytes,
+        };
+
+        // Try to charge the budget
+        if let Err(e) = budget_tracker.charge(&budget_delta) {
+            debug!(
+                episode_id = %handle.episode_id(),
+                error = %e,
+                "budget exhausted during telemetry collection"
+            );
+            return Ok(None);
+        }
+
+        // Create frame
+        let frame =
+            handle
+                .next_frame(stats, o11y_flags)
+                .ok_or_else(|| TelemetryError::Stopped {
+                    episode_id: handle.episode_id().to_string(),
+                })?;
+
+        // Check high-frequency mode threshold
+        self.update_high_freq_mode(handle, budget_tracker);
+
+        Ok(Some(frame))
+    }
+
+    /// Updates high-frequency mode based on budget consumption.
+    fn update_high_freq_mode(&self, handle: &TelemetryHandle, budget_tracker: &BudgetTracker) {
+        if !self.policy.high_freq_enabled() {
+            return;
+        }
+
+        let limits = budget_tracker.limits();
+        let consumed = budget_tracker.consumed();
+
+        // Check CPU budget consumption
+        let cpu_percent = if limits.cpu_ms() > 0 {
+            (consumed.cpu_ms * 100) / limits.cpu_ms()
+        } else {
+            0
+        };
+
+        // Check I/O budget consumption
+        let io_percent = if limits.bytes_io() > 0 {
+            (consumed.bytes_io * 100) / limits.bytes_io()
+        } else {
+            0
+        };
+
+        // Enable high-frequency mode if either threshold exceeded
+        let threshold = u64::from(self.policy.high_freq_threshold_percent());
+        let should_enable = cpu_percent >= threshold || io_percent >= threshold;
+
+        if should_enable != handle.is_high_freq_active() {
+            handle.set_high_freq_active(should_enable);
+            debug!(
+                episode_id = %handle.episode_id(),
+                high_freq = should_enable,
+                cpu_percent,
+                io_percent,
+                "telemetry high-frequency mode changed"
+            );
+        }
+    }
+
+    /// Spawns an async collection loop for periodic telemetry gathering.
+    ///
+    /// This spawns a Tokio task that:
+    /// 1. Sleeps for `sample_interval` (adjusted for high-freq mode)
+    /// 2. Reads metrics from `CgroupReader`
+    /// 3. Reports consumption to `BudgetTracker`
+    /// 4. Pushes frame to the handle's ring buffer
+    /// 5. Sends frame to the output channel
+    ///
+    /// The loop terminates when:
+    /// - The handle is stopped
+    /// - Budget is exhausted
+    /// - The output channel is closed
+    ///
+    /// # Arguments
+    ///
+    /// * `handle` - Active collection handle (wrapped in Arc for sharing)
+    /// * `reader` - Cgroup reader (wrapped in Arc for sharing)
+    /// * `budget_tracker` - Budget tracker (wrapped in Arc for sharing)
+    /// * `output_tx` - Channel for sending frames
+    ///
+    /// # Returns
+    ///
+    /// A `JoinHandle` for the spawned task.
+    pub fn spawn_collection_loop(
+        &self,
+        handle: Arc<TelemetryHandle>,
+        reader: Arc<CgroupReader>,
+        budget_tracker: Arc<BudgetTracker>,
+        output_tx: mpsc::Sender<TelemetryFrame>,
+    ) -> tokio::task::JoinHandle<()> {
+        let policy = self.policy.clone();
+
+        tokio::spawn(async move {
+            let mut is_first = true;
+
+            loop {
+                // Check if stopped
+                if handle.is_stopped() {
+                    debug!(
+                        episode_id = %handle.episode_id(),
+                        "telemetry collection loop stopped"
+                    );
+                    break;
+                }
+
+                // Determine sample interval
+                let sample_ms = policy.effective_sample_period_ms(handle.is_high_freq_active());
+                let sleep_duration = Duration::from_millis(sample_ms);
+
+                // Sleep for the interval
+                sleep(sleep_duration).await;
+
+                // Check again after sleep
+                if handle.is_stopped() {
+                    break;
+                }
+
+                // Read current stats
+                let stats = reader.read_all();
+
+                // Compute delta
+                let (cpu_delta_ns, io_delta_bytes) = handle.compute_delta(&stats);
+
+                // Try to charge budget
+                let budget_delta = BudgetDelta {
+                    tokens: 0,
+                    tool_calls: 0,
+                    wall_ms: 0,
+                    cpu_ms: cpu_delta_ns / 1_000_000,
+                    bytes_io: io_delta_bytes,
+                };
+
+                if let Err(e) = budget_tracker.charge(&budget_delta) {
+                    warn!(
+                        episode_id = %handle.episode_id(),
+                        error = %e,
+                        "budget exhausted in telemetry loop, stopping"
+                    );
+                    break;
+                }
+
+                // Build flags
+                let mut o11y_flags = O11yFlags::new();
+                if is_first {
+                    o11y_flags = o11y_flags.with_initial();
+                    is_first = false;
+                }
+                if handle.is_high_freq_active() {
+                    o11y_flags = o11y_flags.with_high_frequency();
+                }
+                if stats.has_degraded_source() {
+                    o11y_flags = o11y_flags.with_degraded();
+                }
+
+                // Create frame
+                let Some(frame) = handle.next_frame(stats, o11y_flags) else {
+                    break;
+                };
+
+                // Send to output channel
+                if output_tx.send(frame).await.is_err() {
+                    debug!(
+                        episode_id = %handle.episode_id(),
+                        "output channel closed, stopping telemetry loop"
+                    );
+                    break;
+                }
+
+                // Update high-frequency mode
+                update_high_freq_mode_internal(&policy, &handle, &budget_tracker);
+            }
+        })
+    }
+}
+
+/// Internal function to update high-frequency mode.
+fn update_high_freq_mode_internal(
+    policy: &TelemetryPolicy,
+    handle: &TelemetryHandle,
+    budget_tracker: &BudgetTracker,
+) {
+    if !policy.high_freq_enabled() {
+        return;
+    }
+
+    let limits = budget_tracker.limits();
+    let consumed = budget_tracker.consumed();
+
+    let cpu_percent = if limits.cpu_ms() > 0 {
+        (consumed.cpu_ms * 100) / limits.cpu_ms()
+    } else {
+        0
+    };
+
+    let io_percent = if limits.bytes_io() > 0 {
+        (consumed.bytes_io * 100) / limits.bytes_io()
+    } else {
+        0
+    };
+
+    let threshold = u64::from(policy.high_freq_threshold_percent());
+    let should_enable = cpu_percent >= threshold || io_percent >= threshold;
+
+    if should_enable != handle.is_high_freq_active() {
+        handle.set_high_freq_active(should_enable);
+    }
+}
+
+impl Default for TelemetryCollector {
+    fn default() -> Self {
+        Self::with_default_policy()
+    }
+}
+
+impl Clone for TelemetryCollector {
+    fn clone(&self) -> Self {
+        Self {
+            policy: self.policy.clone(),
+        }
+    }
+}
+
+/// Creates a shared telemetry collector wrapped in `Arc`.
+#[must_use]
+pub fn new_shared_collector(policy: TelemetryPolicy) -> Arc<TelemetryCollector> {
+    Arc::new(TelemetryCollector::new(policy))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::episode::EpisodeBudget;
+
+    fn test_episode_id() -> EpisodeId {
+        EpisodeId::new("test-episode-001").expect("valid episode ID")
+    }
+
+    // =========================================================================
+    // UT-00169-01: Frame collection tests
+    // =========================================================================
+
+    #[test]
+    fn test_telemetry_collector_new() {
+        let policy = TelemetryPolicy::default();
+        let collector = TelemetryCollector::new(policy.clone());
+
+        assert_eq!(
+            collector.policy().sample_period_ms(),
+            policy.sample_period_ms()
+        );
+    }
+
+    #[test]
+    fn test_telemetry_collector_start() {
+        let collector = TelemetryCollector::with_default_policy();
+        let handle = collector.start(test_episode_id(), Pid::from_raw(1234));
+
+        assert_eq!(handle.episode_id().as_str(), "test-episode-001");
+        assert_eq!(handle.pid().as_raw(), 1234);
+        assert!(!handle.is_stopped());
+    }
+
+    #[test]
+    fn test_telemetry_collector_apply_policy() {
+        let mut collector = TelemetryCollector::with_default_policy();
+
+        let new_policy = TelemetryPolicy::builder().sample_period_ms(500).build();
+
+        collector.apply_policy(new_policy);
+
+        assert_eq!(collector.policy().sample_period_ms(), 500);
+    }
+
+    #[test]
+    fn test_telemetry_collector_default() {
+        let collector = TelemetryCollector::default();
+        assert_eq!(
+            collector.policy().sample_period_ms(),
+            TelemetryPolicy::default().sample_period_ms()
+        );
+    }
+
+    #[test]
+    fn test_telemetry_collector_clone() {
+        let collector =
+            TelemetryCollector::new(TelemetryPolicy::builder().sample_period_ms(500).build());
+        let cloned = collector.clone();
+
+        assert_eq!(
+            collector.policy().sample_period_ms(),
+            cloned.policy().sample_period_ms()
+        );
+    }
+
+    #[test]
+    fn test_new_shared_collector() {
+        let collector = new_shared_collector(TelemetryPolicy::default());
+        assert_eq!(Arc::strong_count(&collector), 1);
+    }
+
+    // =========================================================================
+    // UT-00169-02: Sample interval tests
+    // =========================================================================
+
+    #[test]
+    fn test_telemetry_policy_effective_sample_period() {
+        let policy = TelemetryPolicy::builder()
+            .sample_period_ms(1000)
+            .high_freq_enabled(true)
+            .build();
+
+        assert_eq!(policy.effective_sample_period_ms(false), 1000);
+        assert_eq!(policy.effective_sample_period_ms(true), 250);
+    }
+
+    #[test]
+    fn test_telemetry_handle_high_freq_mode() {
+        let collector = TelemetryCollector::with_default_policy();
+        let handle = collector.start(test_episode_id(), Pid::from_raw(1234));
+
+        assert!(!handle.is_high_freq_active());
+        handle.set_high_freq_active(true);
+        assert!(handle.is_high_freq_active());
+    }
+
+    // =========================================================================
+    // IT-00169-01: Budget integration tests
+    // =========================================================================
+
+    #[test]
+    fn test_budget_delta_from_telemetry() {
+        // Simulate telemetry delta conversion
+        let cpu_ns: u64 = 1_500_000_000; // 1.5 seconds
+        let io_bytes: u64 = 1_048_576; // 1 MiB
+
+        let budget_delta = BudgetDelta {
+            tokens: 0,
+            tool_calls: 0,
+            wall_ms: 0,
+            cpu_ms: cpu_ns / 1_000_000,
+            bytes_io: io_bytes,
+        };
+
+        assert_eq!(budget_delta.cpu_ms, 1500);
+        assert_eq!(budget_delta.bytes_io, 1_048_576);
+    }
+
+    #[test]
+    fn test_budget_tracker_charge_from_telemetry() {
+        let budget = EpisodeBudget::builder()
+            .cpu_ms(10_000)
+            .bytes_io(10_000_000)
+            .build();
+
+        let tracker = BudgetTracker::from_envelope(budget);
+
+        // Simulate telemetry charging
+        let delta = BudgetDelta {
+            tokens: 0,
+            tool_calls: 0,
+            wall_ms: 0,
+            cpu_ms: 1000,
+            bytes_io: 1_000_000,
+        };
+
+        assert!(tracker.charge(&delta).is_ok());
+
+        let remaining = tracker.remaining();
+        assert_eq!(remaining.cpu_ms(), 9000);
+        assert_eq!(remaining.bytes_io(), 9_000_000);
+    }
+
+    #[test]
+    fn test_budget_exhaustion_detection() {
+        let budget = EpisodeBudget::builder().cpu_ms(100).bytes_io(1000).build();
+
+        let tracker = BudgetTracker::from_envelope(budget);
+
+        // First charge succeeds
+        let delta1 = BudgetDelta {
+            tokens: 0,
+            tool_calls: 0,
+            wall_ms: 0,
+            cpu_ms: 50,
+            bytes_io: 500,
+        };
+        assert!(tracker.charge(&delta1).is_ok());
+
+        // Second charge exceeds budget
+        let delta2 = BudgetDelta {
+            tokens: 0,
+            tool_calls: 0,
+            wall_ms: 0,
+            cpu_ms: 100, // Would exceed
+            bytes_io: 100,
+        };
+        assert!(tracker.charge(&delta2).is_err());
+    }
+
+    #[test]
+    fn test_high_freq_threshold_calculation() {
+        let budget = EpisodeBudget::builder()
+            .cpu_ms(1000)
+            .bytes_io(10_000)
+            .build();
+
+        let tracker = BudgetTracker::from_envelope(budget);
+
+        // Charge 80% of CPU budget
+        let delta = BudgetDelta {
+            tokens: 0,
+            tool_calls: 0,
+            wall_ms: 0,
+            cpu_ms: 800,
+            bytes_io: 0,
+        };
+        tracker.charge(&delta).unwrap();
+
+        let consumed = tracker.consumed();
+        let limits = tracker.limits();
+
+        let cpu_percent = (consumed.cpu_ms * 100) / limits.cpu_ms();
+        assert_eq!(cpu_percent, 80);
+
+        // With threshold at 80%, high-freq should be enabled
+        let threshold = 80_u64;
+        assert!(cpu_percent >= threshold);
+    }
+
+    // =========================================================================
+    // Error type tests
+    // =========================================================================
+
+    #[test]
+    fn test_telemetry_error_display() {
+        let err = TelemetryError::Stopped {
+            episode_id: "test-ep".to_string(),
+        };
+        assert!(err.to_string().contains("test-ep"));
+
+        let err = TelemetryError::CgroupUnavailable {
+            episode_id: "test-ep".to_string(),
+        };
+        assert!(err.to_string().contains("cgroup reader unavailable"));
+
+        let err = TelemetryError::InvalidConfig {
+            reason: "bad config".to_string(),
+        };
+        assert!(err.to_string().contains("bad config"));
+    }
+}

--- a/crates/apm2-daemon/src/telemetry/frame.rs
+++ b/crates/apm2-daemon/src/telemetry/frame.rs
@@ -1,0 +1,718 @@
+//! Telemetry frame type for resource metrics.
+//!
+//! This module defines the `TelemetryFrame` type per CTR-DAEMON-005,
+//! representing a single telemetry sample collected during episode execution.
+//!
+//! # Architecture
+//!
+//! ```text
+//! TelemetryCollector
+//!       |
+//!       +-- collect() --> TelemetryFrame
+//!                             |
+//!                             +-- episode_id, seq, ts_mono
+//!                             +-- cpu_ns, cpu_user_ns, cpu_system_ns
+//!                             +-- mem_rss_bytes, mem_peak_bytes
+//!                             +-- io_read_bytes, io_write_bytes
+//!                             +-- o11y_flags
+//! ```
+//!
+//! # Invariants
+//!
+//! - [INV-TF001] Sequence numbers are monotonically increasing per episode
+//! - [INV-TF002] All values are bounded to prevent overflow
+//! - [INV-TF003] Timestamps are monotonic (from `CLOCK_MONOTONIC`)
+//!
+//! # Contract References
+//!
+//! - CTR-DAEMON-005: `TelemetryCollector` and frame streaming
+
+use serde::{Deserialize, Serialize};
+
+use super::stats::MetricSource;
+use crate::episode::EpisodeId;
+
+/// Maximum nanoseconds value (prevents overflow in calculations).
+pub const MAX_FRAME_NS: u64 = u64::MAX / 2;
+
+/// Maximum bytes value (prevents overflow in calculations).
+pub const MAX_FRAME_BYTES: u64 = u64::MAX / 2;
+
+/// Observability flags for telemetry sampling mode.
+///
+/// These flags indicate the collection mode and any special conditions
+/// during frame capture.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::struct_excessive_bools)] // Flags struct intentionally uses bools
+pub struct O11yFlags {
+    /// Frame was collected during high-frequency sampling (e.g., budget nearing
+    /// exhaustion).
+    pub high_frequency: bool,
+
+    /// Frame was promoted from ring buffer to persistent storage.
+    pub promoted: bool,
+
+    /// Frame was collected during degraded mode (proc fallback).
+    pub degraded: bool,
+
+    /// Frame was the first sample after episode start.
+    pub initial: bool,
+
+    /// Frame was the final sample before episode termination.
+    pub terminal: bool,
+}
+
+impl O11yFlags {
+    /// Creates a new empty flags instance.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            high_frequency: false,
+            promoted: false,
+            degraded: false,
+            initial: false,
+            terminal: false,
+        }
+    }
+
+    /// Sets the initial flag.
+    #[must_use]
+    pub const fn with_initial(mut self) -> Self {
+        self.initial = true;
+        self
+    }
+
+    /// Sets the terminal flag.
+    #[must_use]
+    pub const fn with_terminal(mut self) -> Self {
+        self.terminal = true;
+        self
+    }
+
+    /// Sets the degraded flag.
+    #[must_use]
+    pub const fn with_degraded(mut self) -> Self {
+        self.degraded = true;
+        self
+    }
+
+    /// Sets the high-frequency flag.
+    #[must_use]
+    pub const fn with_high_frequency(mut self) -> Self {
+        self.high_frequency = true;
+        self
+    }
+
+    /// Sets the promoted flag.
+    #[must_use]
+    pub const fn with_promoted(mut self) -> Self {
+        self.promoted = true;
+        self
+    }
+
+    /// Returns `true` if any special flag is set.
+    #[must_use]
+    pub const fn has_any(&self) -> bool {
+        self.high_frequency || self.promoted || self.degraded || self.initial || self.terminal
+    }
+}
+
+/// A single telemetry frame capturing resource metrics at a point in time.
+///
+/// Per CTR-DAEMON-005, each frame contains:
+/// - Episode identity and sequence
+/// - CPU time (total, user, system)
+/// - Memory usage (RSS, peak)
+/// - I/O metrics (read/write bytes)
+/// - Observability flags
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use apm2_daemon::telemetry::TelemetryFrame;
+/// use apm2_daemon::episode::EpisodeId;
+///
+/// let frame = TelemetryFrame::builder(EpisodeId::new("ep-001")?, 0)
+///     .ts_mono(1234567890)
+///     .cpu_ns(1_000_000)
+///     .mem_rss_bytes(1024 * 1024)
+///     .build();
+///
+/// assert_eq!(frame.seq(), 0);
+/// assert_eq!(frame.cpu_ns(), 1_000_000);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TelemetryFrame {
+    /// Episode identifier.
+    episode_id: EpisodeId,
+
+    /// Sequence number (monotonically increasing per episode).
+    seq: u64,
+
+    /// Monotonic timestamp in nanoseconds (from `CLOCK_MONOTONIC`).
+    ts_mono: u64,
+
+    /// Total CPU time in nanoseconds.
+    cpu_ns: u64,
+
+    /// User-mode CPU time in nanoseconds.
+    cpu_user_ns: u64,
+
+    /// Kernel-mode CPU time in nanoseconds.
+    cpu_system_ns: u64,
+
+    /// Resident set size in bytes.
+    mem_rss_bytes: u64,
+
+    /// Peak memory usage in bytes.
+    mem_peak_bytes: u64,
+
+    /// I/O bytes read.
+    io_read_bytes: u64,
+
+    /// I/O bytes written.
+    io_write_bytes: u64,
+
+    /// Metric source (cgroup vs proc fallback).
+    source: MetricSource,
+
+    /// Observability flags.
+    o11y_flags: O11yFlags,
+}
+
+impl TelemetryFrame {
+    /// Creates a new frame builder.
+    #[must_use]
+    pub const fn builder(episode_id: EpisodeId, seq: u64) -> TelemetryFrameBuilder {
+        TelemetryFrameBuilder::new(episode_id, seq)
+    }
+
+    /// Creates a frame with invariant validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string if any invariant is violated.
+    #[allow(clippy::too_many_arguments)] // Frame has many metrics by design
+    pub fn try_new(
+        episode_id: EpisodeId,
+        seq: u64,
+        ts_mono: u64,
+        cpu_ns: u64,
+        cpu_user_ns: u64,
+        cpu_system_ns: u64,
+        mem_rss_bytes: u64,
+        mem_peak_bytes: u64,
+        io_read_bytes: u64,
+        io_write_bytes: u64,
+        source: MetricSource,
+        o11y_flags: O11yFlags,
+    ) -> Result<Self, String> {
+        let frame = Self {
+            episode_id,
+            seq,
+            ts_mono: clamp_ns(ts_mono),
+            cpu_ns: clamp_ns(cpu_ns),
+            cpu_user_ns: clamp_ns(cpu_user_ns),
+            cpu_system_ns: clamp_ns(cpu_system_ns),
+            mem_rss_bytes: clamp_bytes(mem_rss_bytes),
+            mem_peak_bytes: clamp_bytes(mem_peak_bytes),
+            io_read_bytes: clamp_bytes(io_read_bytes),
+            io_write_bytes: clamp_bytes(io_write_bytes),
+            source,
+            o11y_flags,
+        };
+        frame.validate()?;
+        Ok(frame)
+    }
+
+    /// Validates frame invariants.
+    ///
+    /// # Invariants
+    ///
+    /// - [INV-TF002] All values are bounded by MAX_* constants
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string describing the violated invariant.
+    pub fn validate(&self) -> Result<(), String> {
+        // INV-TF002: Validate bounded values
+        if self.ts_mono > MAX_FRAME_NS {
+            return Err(format!(
+                "INV-TF002 violated: ts_mono ({}) exceeds MAX_FRAME_NS",
+                self.ts_mono
+            ));
+        }
+        if self.cpu_ns > MAX_FRAME_NS {
+            return Err(format!(
+                "INV-TF002 violated: cpu_ns ({}) exceeds MAX_FRAME_NS",
+                self.cpu_ns
+            ));
+        }
+        if self.mem_rss_bytes > MAX_FRAME_BYTES {
+            return Err(format!(
+                "INV-TF002 violated: mem_rss_bytes ({}) exceeds MAX_FRAME_BYTES",
+                self.mem_rss_bytes
+            ));
+        }
+        if self.mem_peak_bytes > MAX_FRAME_BYTES {
+            return Err(format!(
+                "INV-TF002 violated: mem_peak_bytes ({}) exceeds MAX_FRAME_BYTES",
+                self.mem_peak_bytes
+            ));
+        }
+        Ok(())
+    }
+
+    // =========================================================================
+    // Accessors
+    // =========================================================================
+
+    /// Returns the episode ID.
+    #[must_use]
+    pub const fn episode_id(&self) -> &EpisodeId {
+        &self.episode_id
+    }
+
+    /// Returns the sequence number.
+    #[must_use]
+    pub const fn seq(&self) -> u64 {
+        self.seq
+    }
+
+    /// Returns the monotonic timestamp in nanoseconds.
+    #[must_use]
+    pub const fn ts_mono(&self) -> u64 {
+        self.ts_mono
+    }
+
+    /// Returns the total CPU time in nanoseconds.
+    #[must_use]
+    pub const fn cpu_ns(&self) -> u64 {
+        self.cpu_ns
+    }
+
+    /// Returns the user-mode CPU time in nanoseconds.
+    #[must_use]
+    pub const fn cpu_user_ns(&self) -> u64 {
+        self.cpu_user_ns
+    }
+
+    /// Returns the kernel-mode CPU time in nanoseconds.
+    #[must_use]
+    pub const fn cpu_system_ns(&self) -> u64 {
+        self.cpu_system_ns
+    }
+
+    /// Returns the resident set size in bytes.
+    #[must_use]
+    pub const fn mem_rss_bytes(&self) -> u64 {
+        self.mem_rss_bytes
+    }
+
+    /// Returns the peak memory usage in bytes.
+    #[must_use]
+    pub const fn mem_peak_bytes(&self) -> u64 {
+        self.mem_peak_bytes
+    }
+
+    /// Returns the I/O bytes read.
+    #[must_use]
+    pub const fn io_read_bytes(&self) -> u64 {
+        self.io_read_bytes
+    }
+
+    /// Returns the I/O bytes written.
+    #[must_use]
+    pub const fn io_write_bytes(&self) -> u64 {
+        self.io_write_bytes
+    }
+
+    /// Returns the total I/O bytes (read + write).
+    #[must_use]
+    pub const fn io_total_bytes(&self) -> u64 {
+        self.io_read_bytes.saturating_add(self.io_write_bytes)
+    }
+
+    /// Returns the metric source.
+    #[must_use]
+    pub const fn source(&self) -> MetricSource {
+        self.source
+    }
+
+    /// Returns the observability flags.
+    #[must_use]
+    pub const fn o11y_flags(&self) -> &O11yFlags {
+        &self.o11y_flags
+    }
+
+    /// Returns the CPU time in milliseconds.
+    #[must_use]
+    pub const fn cpu_ms(&self) -> u64 {
+        self.cpu_ns / 1_000_000
+    }
+
+    /// Returns `true` if metrics are from the cgroup source.
+    #[must_use]
+    pub const fn is_from_cgroup(&self) -> bool {
+        self.source.is_cgroup()
+    }
+
+    /// Returns `true` if metrics are from the degraded proc source.
+    #[must_use]
+    pub const fn is_degraded(&self) -> bool {
+        self.source.is_proc()
+    }
+}
+
+/// Builder for [`TelemetryFrame`].
+#[derive(Debug, Clone)]
+pub struct TelemetryFrameBuilder {
+    episode_id: EpisodeId,
+    seq: u64,
+    ts_mono: u64,
+    cpu_ns: u64,
+    cpu_user_ns: u64,
+    cpu_system_ns: u64,
+    mem_rss_bytes: u64,
+    mem_peak_bytes: u64,
+    io_read_bytes: u64,
+    io_write_bytes: u64,
+    source: MetricSource,
+    o11y_flags: O11yFlags,
+}
+
+impl TelemetryFrameBuilder {
+    /// Creates a new builder with required fields.
+    #[must_use]
+    pub const fn new(episode_id: EpisodeId, seq: u64) -> Self {
+        Self {
+            episode_id,
+            seq,
+            ts_mono: 0,
+            cpu_ns: 0,
+            cpu_user_ns: 0,
+            cpu_system_ns: 0,
+            mem_rss_bytes: 0,
+            mem_peak_bytes: 0,
+            io_read_bytes: 0,
+            io_write_bytes: 0,
+            source: MetricSource::Unavailable,
+            o11y_flags: O11yFlags::new(),
+        }
+    }
+
+    /// Sets the monotonic timestamp.
+    #[must_use]
+    pub const fn ts_mono(mut self, ts_mono: u64) -> Self {
+        self.ts_mono = ts_mono;
+        self
+    }
+
+    /// Sets the total CPU time in nanoseconds.
+    #[must_use]
+    pub const fn cpu_ns(mut self, cpu_ns: u64) -> Self {
+        self.cpu_ns = cpu_ns;
+        self
+    }
+
+    /// Sets the user-mode CPU time in nanoseconds.
+    #[must_use]
+    pub const fn cpu_user_ns(mut self, cpu_user_ns: u64) -> Self {
+        self.cpu_user_ns = cpu_user_ns;
+        self
+    }
+
+    /// Sets the kernel-mode CPU time in nanoseconds.
+    #[must_use]
+    pub const fn cpu_system_ns(mut self, cpu_system_ns: u64) -> Self {
+        self.cpu_system_ns = cpu_system_ns;
+        self
+    }
+
+    /// Sets the resident set size in bytes.
+    #[must_use]
+    pub const fn mem_rss_bytes(mut self, mem_rss_bytes: u64) -> Self {
+        self.mem_rss_bytes = mem_rss_bytes;
+        self
+    }
+
+    /// Sets the peak memory usage in bytes.
+    #[must_use]
+    pub const fn mem_peak_bytes(mut self, mem_peak_bytes: u64) -> Self {
+        self.mem_peak_bytes = mem_peak_bytes;
+        self
+    }
+
+    /// Sets the I/O bytes read.
+    #[must_use]
+    pub const fn io_read_bytes(mut self, io_read_bytes: u64) -> Self {
+        self.io_read_bytes = io_read_bytes;
+        self
+    }
+
+    /// Sets the I/O bytes written.
+    #[must_use]
+    pub const fn io_write_bytes(mut self, io_write_bytes: u64) -> Self {
+        self.io_write_bytes = io_write_bytes;
+        self
+    }
+
+    /// Sets the metric source.
+    #[must_use]
+    pub const fn source(mut self, source: MetricSource) -> Self {
+        self.source = source;
+        self
+    }
+
+    /// Sets the observability flags.
+    #[must_use]
+    pub const fn o11y_flags(mut self, o11y_flags: O11yFlags) -> Self {
+        self.o11y_flags = o11y_flags;
+        self
+    }
+
+    /// Builds the frame.
+    #[must_use]
+    pub fn build(self) -> TelemetryFrame {
+        TelemetryFrame {
+            episode_id: self.episode_id,
+            seq: self.seq,
+            ts_mono: clamp_ns(self.ts_mono),
+            cpu_ns: clamp_ns(self.cpu_ns),
+            cpu_user_ns: clamp_ns(self.cpu_user_ns),
+            cpu_system_ns: clamp_ns(self.cpu_system_ns),
+            mem_rss_bytes: clamp_bytes(self.mem_rss_bytes),
+            mem_peak_bytes: clamp_bytes(self.mem_peak_bytes),
+            io_read_bytes: clamp_bytes(self.io_read_bytes),
+            io_write_bytes: clamp_bytes(self.io_write_bytes),
+            source: self.source,
+            o11y_flags: self.o11y_flags,
+        }
+    }
+
+    /// Builds the frame with validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string if any invariant is violated.
+    pub fn try_build(self) -> Result<TelemetryFrame, String> {
+        let frame = self.build();
+        frame.validate()?;
+        Ok(frame)
+    }
+}
+
+/// Clamps a nanosecond value to `MAX_FRAME_NS`.
+const fn clamp_ns(value: u64) -> u64 {
+    if value > MAX_FRAME_NS {
+        MAX_FRAME_NS
+    } else {
+        value
+    }
+}
+
+/// Clamps a byte value to `MAX_FRAME_BYTES`.
+const fn clamp_bytes(value: u64) -> u64 {
+    if value > MAX_FRAME_BYTES {
+        MAX_FRAME_BYTES
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_episode_id() -> EpisodeId {
+        EpisodeId::new("test-episode-001").expect("valid episode ID")
+    }
+
+    // =========================================================================
+    // UT-00169-01: Frame collection tests
+    // =========================================================================
+
+    #[test]
+    fn test_telemetry_frame_builder() {
+        let frame = TelemetryFrame::builder(test_episode_id(), 0)
+            .ts_mono(1_000_000_000)
+            .cpu_ns(500_000_000)
+            .cpu_user_ns(300_000_000)
+            .cpu_system_ns(200_000_000)
+            .mem_rss_bytes(1024 * 1024 * 100)
+            .mem_peak_bytes(1024 * 1024 * 150)
+            .io_read_bytes(1024 * 1024)
+            .io_write_bytes(512 * 1024)
+            .source(MetricSource::Cgroup)
+            .build();
+
+        assert_eq!(frame.seq(), 0);
+        assert_eq!(frame.ts_mono(), 1_000_000_000);
+        assert_eq!(frame.cpu_ns(), 500_000_000);
+        assert_eq!(frame.cpu_user_ns(), 300_000_000);
+        assert_eq!(frame.cpu_system_ns(), 200_000_000);
+        assert_eq!(frame.mem_rss_bytes(), 104_857_600);
+        assert_eq!(frame.mem_peak_bytes(), 157_286_400);
+        assert_eq!(frame.io_read_bytes(), 1_048_576);
+        assert_eq!(frame.io_write_bytes(), 524_288);
+        assert!(frame.is_from_cgroup());
+    }
+
+    #[test]
+    fn test_telemetry_frame_try_new() {
+        let result = TelemetryFrame::try_new(
+            test_episode_id(),
+            1,
+            1_000_000_000,
+            500_000_000,
+            300_000_000,
+            200_000_000,
+            104_857_600,
+            157_286_400,
+            1_048_576,
+            524_288,
+            MetricSource::Cgroup,
+            O11yFlags::new(),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_telemetry_frame_clamping() {
+        let frame = TelemetryFrame::builder(test_episode_id(), 0)
+            .ts_mono(u64::MAX)
+            .cpu_ns(u64::MAX)
+            .mem_rss_bytes(u64::MAX)
+            .build();
+
+        assert_eq!(frame.ts_mono(), MAX_FRAME_NS);
+        assert_eq!(frame.cpu_ns(), MAX_FRAME_NS);
+        assert_eq!(frame.mem_rss_bytes(), MAX_FRAME_BYTES);
+    }
+
+    #[test]
+    fn test_telemetry_frame_validate() {
+        let frame = TelemetryFrame::builder(test_episode_id(), 0)
+            .cpu_ns(1_000_000)
+            .build();
+        assert!(frame.validate().is_ok());
+    }
+
+    #[test]
+    fn test_telemetry_frame_io_total() {
+        let frame = TelemetryFrame::builder(test_episode_id(), 0)
+            .io_read_bytes(100)
+            .io_write_bytes(200)
+            .build();
+        assert_eq!(frame.io_total_bytes(), 300);
+    }
+
+    #[test]
+    fn test_telemetry_frame_cpu_ms() {
+        let frame = TelemetryFrame::builder(test_episode_id(), 0)
+            .cpu_ns(1_500_000_000)
+            .build();
+        assert_eq!(frame.cpu_ms(), 1500);
+    }
+
+    #[test]
+    fn test_telemetry_frame_degraded() {
+        let frame = TelemetryFrame::builder(test_episode_id(), 0)
+            .source(MetricSource::Proc)
+            .build();
+        assert!(frame.is_degraded());
+        assert!(!frame.is_from_cgroup());
+    }
+
+    // =========================================================================
+    // O11yFlags tests
+    // =========================================================================
+
+    #[test]
+    fn test_o11y_flags_new() {
+        let flags = O11yFlags::new();
+        assert!(!flags.high_frequency);
+        assert!(!flags.promoted);
+        assert!(!flags.degraded);
+        assert!(!flags.initial);
+        assert!(!flags.terminal);
+        assert!(!flags.has_any());
+    }
+
+    #[test]
+    fn test_o11y_flags_with_initial() {
+        let flags = O11yFlags::new().with_initial();
+        assert!(flags.initial);
+        assert!(flags.has_any());
+    }
+
+    #[test]
+    fn test_o11y_flags_with_terminal() {
+        let flags = O11yFlags::new().with_terminal();
+        assert!(flags.terminal);
+        assert!(flags.has_any());
+    }
+
+    #[test]
+    fn test_o11y_flags_with_degraded() {
+        let flags = O11yFlags::new().with_degraded();
+        assert!(flags.degraded);
+        assert!(flags.has_any());
+    }
+
+    #[test]
+    fn test_o11y_flags_with_high_frequency() {
+        let flags = O11yFlags::new().with_high_frequency();
+        assert!(flags.high_frequency);
+        assert!(flags.has_any());
+    }
+
+    #[test]
+    fn test_o11y_flags_with_promoted() {
+        let flags = O11yFlags::new().with_promoted();
+        assert!(flags.promoted);
+        assert!(flags.has_any());
+    }
+
+    #[test]
+    fn test_o11y_flags_chained() {
+        let flags = O11yFlags::new()
+            .with_initial()
+            .with_degraded()
+            .with_high_frequency();
+        assert!(flags.initial);
+        assert!(flags.degraded);
+        assert!(flags.high_frequency);
+        assert!(!flags.terminal);
+        assert!(!flags.promoted);
+    }
+
+    // =========================================================================
+    // Serialization tests
+    // =========================================================================
+
+    #[test]
+    fn test_telemetry_frame_serialize() {
+        let frame = TelemetryFrame::builder(test_episode_id(), 42)
+            .ts_mono(1_000_000_000)
+            .cpu_ns(500_000_000)
+            .source(MetricSource::Cgroup)
+            .o11y_flags(O11yFlags::new().with_initial())
+            .build();
+
+        let json = serde_json::to_string(&frame).expect("serialize failed");
+        let decoded: TelemetryFrame = serde_json::from_str(&json).expect("deserialize failed");
+
+        assert_eq!(frame, decoded);
+    }
+
+    #[test]
+    fn test_o11y_flags_serialize() {
+        let flags = O11yFlags::new().with_initial().with_degraded();
+        let json = serde_json::to_string(&flags).expect("serialize failed");
+        let decoded: O11yFlags = serde_json::from_str(&json).expect("deserialize failed");
+        assert_eq!(flags, decoded);
+    }
+}

--- a/crates/apm2-daemon/src/telemetry/handle.rs
+++ b/crates/apm2-daemon/src/telemetry/handle.rs
@@ -1,0 +1,619 @@
+//! Telemetry handle for active collection sessions.
+//!
+//! This module provides the `TelemetryHandle` type per CTR-DAEMON-005,
+//! representing an active telemetry collection session for an episode.
+//!
+//! # Architecture
+//!
+//! ```text
+//! TelemetryCollector::start()
+//!         |
+//!         v
+//! TelemetryHandle
+//!     |
+//!     +-- episode_id: identifies the episode
+//!     +-- pid: process to monitor
+//!     +-- seq_gen: sequence number generator
+//!     +-- ring_buffer: recent frames
+//!     +-- start_mono_ns: collection start time
+//!     +-- prev_stats: for computing deltas
+//! ```
+//!
+//! # Thread Safety
+//!
+//! `TelemetryHandle` uses interior mutability for thread-safe access:
+//! - Sequence number uses `AtomicU64`
+//! - Ring buffer and stats use `Mutex` (short-held)
+//! - All methods are safe to call from multiple threads
+//!
+//! # Contract References
+//!
+//! - CTR-DAEMON-005: `TelemetryCollector` and frame streaming
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Instant;
+
+use nix::unistd::Pid;
+
+use super::frame::{O11yFlags, TelemetryFrame};
+use super::stats::ResourceStats;
+use crate::episode::{EpisodeId, RingBuffer};
+
+/// Maximum sequence number before wrapping.
+///
+/// We use a large but not maximal value to detect overflow conditions.
+pub const MAX_SEQUENCE: u64 = u64::MAX / 2;
+
+/// Telemetry handle for an active collection session.
+///
+/// Returned by `TelemetryCollector::start()`, this handle tracks the
+/// state of telemetry collection for a single episode.
+///
+/// # Invariants
+///
+/// - [INV-TH001] Sequence numbers are monotonically increasing
+/// - [INV-TH002] Ring buffer capacity is bounded by policy
+/// - [INV-TH003] Handle is invalidated after `stop()` is called
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use apm2_daemon::telemetry::{TelemetryCollector, TelemetryPolicy};
+/// use apm2_daemon::episode::EpisodeId;
+/// use nix::unistd::Pid;
+///
+/// let collector = TelemetryCollector::new(TelemetryPolicy::default());
+/// let handle = collector.start(
+///     EpisodeId::new("ep-001")?,
+///     Pid::from_raw(1234),
+/// );
+///
+/// // Collect frames
+/// let frame = handle.next_frame(stats, mono_ns, o11y_flags);
+///
+/// // Stop collection
+/// let frames = handle.stop();
+/// ```
+#[derive(Debug)]
+pub struct TelemetryHandle {
+    /// Episode identifier.
+    episode_id: EpisodeId,
+
+    /// Process ID being monitored.
+    pid: Pid,
+
+    /// Monotonically increasing sequence number.
+    seq: AtomicU64,
+
+    /// Ring buffer of recent frames.
+    ring_buffer: Mutex<RingBuffer<TelemetryFrame>>,
+
+    /// Start time (monotonic) for relative timestamps.
+    start_mono: Instant,
+
+    /// Previous stats for computing deltas.
+    prev_stats: Mutex<Option<ResourceStats>>,
+
+    /// Whether collection has been stopped.
+    stopped: AtomicBool,
+
+    /// Whether high-frequency mode is active.
+    high_freq_active: AtomicBool,
+
+    /// Total frames collected.
+    frames_collected: AtomicU64,
+
+    /// Total frames promoted to persistent storage.
+    frames_promoted: AtomicU64,
+}
+
+impl TelemetryHandle {
+    /// Creates a new telemetry handle.
+    ///
+    /// # Arguments
+    ///
+    /// * `episode_id` - Episode identifier
+    /// * `pid` - Process ID to monitor
+    /// * `ring_buffer_capacity` - Maximum frames to retain
+    #[must_use]
+    pub fn new(episode_id: EpisodeId, pid: Pid, ring_buffer_capacity: usize) -> Self {
+        Self {
+            episode_id,
+            pid,
+            seq: AtomicU64::new(0),
+            ring_buffer: Mutex::new(RingBuffer::new(ring_buffer_capacity.max(1))),
+            start_mono: Instant::now(),
+            prev_stats: Mutex::new(None),
+            stopped: AtomicBool::new(false),
+            high_freq_active: AtomicBool::new(false),
+            frames_collected: AtomicU64::new(0),
+            frames_promoted: AtomicU64::new(0),
+        }
+    }
+
+    /// Returns the episode ID.
+    #[must_use]
+    pub const fn episode_id(&self) -> &EpisodeId {
+        &self.episode_id
+    }
+
+    /// Returns the process ID.
+    #[must_use]
+    pub const fn pid(&self) -> Pid {
+        self.pid
+    }
+
+    /// Returns the current sequence number.
+    #[must_use]
+    pub fn seq(&self) -> u64 {
+        self.seq.load(Ordering::Relaxed)
+    }
+
+    /// Returns the start time.
+    #[must_use]
+    pub const fn start_mono(&self) -> Instant {
+        self.start_mono
+    }
+
+    /// Returns `true` if collection has been stopped.
+    #[must_use]
+    pub fn is_stopped(&self) -> bool {
+        self.stopped.load(Ordering::Relaxed)
+    }
+
+    /// Returns `true` if high-frequency mode is active.
+    #[must_use]
+    pub fn is_high_freq_active(&self) -> bool {
+        self.high_freq_active.load(Ordering::Relaxed)
+    }
+
+    /// Sets the high-frequency mode state.
+    pub fn set_high_freq_active(&self, active: bool) {
+        self.high_freq_active.store(active, Ordering::Relaxed);
+    }
+
+    /// Returns the total frames collected.
+    #[must_use]
+    pub fn frames_collected(&self) -> u64 {
+        self.frames_collected.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total frames promoted.
+    #[must_use]
+    pub fn frames_promoted(&self) -> u64 {
+        self.frames_promoted.load(Ordering::Relaxed)
+    }
+
+    /// Returns the elapsed time since collection started.
+    #[must_use]
+    pub fn elapsed(&self) -> std::time::Duration {
+        self.start_mono.elapsed()
+    }
+
+    /// Returns the elapsed time in nanoseconds.
+    #[must_use]
+    pub fn elapsed_ns(&self) -> u64 {
+        self.elapsed()
+            .as_nanos()
+            .try_into()
+            .unwrap_or(super::frame::MAX_FRAME_NS)
+    }
+
+    /// Returns the number of frames in the ring buffer.
+    #[must_use]
+    pub fn buffer_len(&self) -> usize {
+        self.ring_buffer.lock().map(|buf| buf.len()).unwrap_or(0)
+    }
+
+    /// Returns the ring buffer capacity.
+    #[must_use]
+    pub fn buffer_capacity(&self) -> usize {
+        self.ring_buffer
+            .lock()
+            .map(|buf| buf.capacity())
+            .unwrap_or(0)
+    }
+
+    /// Gets the next sequence number (atomically incremented).
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(seq)` if sequence is valid, `None` if overflow would
+    /// occur.
+    fn next_seq(&self) -> Option<u64> {
+        loop {
+            let current = self.seq.load(Ordering::Relaxed);
+            if current >= MAX_SEQUENCE {
+                return None;
+            }
+            let next = current + 1;
+            if self
+                .seq
+                .compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                return Some(current);
+            }
+        }
+    }
+
+    /// Creates a new telemetry frame from the given stats.
+    ///
+    /// # Arguments
+    ///
+    /// * `stats` - Current resource stats
+    /// * `o11y_flags` - Observability flags for this frame
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(frame)` if created successfully, `None` if:
+    /// - Collection is stopped
+    /// - Sequence number overflow
+    pub fn next_frame(
+        &self,
+        stats: ResourceStats,
+        o11y_flags: O11yFlags,
+    ) -> Option<TelemetryFrame> {
+        if self.is_stopped() {
+            return None;
+        }
+
+        let seq = self.next_seq()?;
+        let ts_mono = self.elapsed_ns();
+
+        // Determine source from stats
+        let source = if stats.cpu.source().is_cgroup() {
+            super::stats::MetricSource::Cgroup
+        } else if stats.cpu.source().is_proc() {
+            super::stats::MetricSource::Proc
+        } else {
+            super::stats::MetricSource::Unavailable
+        };
+
+        // Build the frame
+        let frame = TelemetryFrame::builder(self.episode_id.clone(), seq)
+            .ts_mono(ts_mono)
+            .cpu_ns(stats.cpu.usage_ns())
+            .cpu_user_ns(stats.cpu.user_ns())
+            .cpu_system_ns(stats.cpu.system_ns())
+            .mem_rss_bytes(stats.memory.rss_bytes())
+            .mem_peak_bytes(stats.memory.peak_bytes())
+            .io_read_bytes(stats.io.read_bytes())
+            .io_write_bytes(stats.io.write_bytes())
+            .source(source)
+            .o11y_flags(o11y_flags)
+            .build();
+
+        // Store in ring buffer
+        if let Ok(mut buffer) = self.ring_buffer.lock() {
+            buffer.push(frame.clone());
+        }
+
+        // Update stats
+        self.frames_collected.fetch_add(1, Ordering::Relaxed);
+
+        // Store previous stats for delta computation
+        if let Ok(mut prev) = self.prev_stats.lock() {
+            *prev = Some(stats);
+        }
+
+        Some(frame)
+    }
+
+    /// Returns the previous stats for delta computation.
+    #[must_use]
+    pub fn prev_stats(&self) -> Option<ResourceStats> {
+        self.prev_stats.lock().map(|guard| *guard).unwrap_or(None)
+    }
+
+    /// Computes the delta between current and previous stats.
+    ///
+    /// Returns `(cpu_delta_ns, io_delta_bytes)` representing the resources
+    /// consumed since the last frame.
+    #[must_use]
+    pub fn compute_delta(&self, current: &ResourceStats) -> (u64, u64) {
+        let prev = self.prev_stats();
+
+        let cpu_delta = prev.map_or_else(
+            || current.cpu.usage_ns(),
+            |p| current.cpu.usage_ns().saturating_sub(p.cpu.usage_ns()),
+        );
+
+        let io_delta = prev.map_or_else(
+            || current.io.total_bytes(),
+            |p| current.io.total_bytes().saturating_sub(p.io.total_bytes()),
+        );
+
+        (cpu_delta, io_delta)
+    }
+
+    /// Drains all frames from the ring buffer.
+    ///
+    /// This is typically called when promoting frames to persistent storage.
+    pub fn drain_frames(&self) -> Vec<TelemetryFrame> {
+        let mut frames = Vec::new();
+        if let Ok(mut buffer) = self.ring_buffer.lock() {
+            frames.extend(buffer.drain());
+        }
+        let count = frames.len() as u64;
+        self.frames_promoted.fetch_add(count, Ordering::Relaxed);
+        frames
+    }
+
+    /// Returns an iterator over frames in the ring buffer (oldest first).
+    ///
+    /// Note: This clones the frames to avoid holding the lock.
+    pub fn iter_frames(&self) -> Vec<TelemetryFrame> {
+        self.ring_buffer
+            .lock()
+            .map(|buffer| buffer.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Stops telemetry collection.
+    ///
+    /// After calling this, `next_frame()` will return `None`.
+    /// Returns the final frames from the ring buffer.
+    pub fn stop(&self) -> Vec<TelemetryFrame> {
+        self.stopped.store(true, Ordering::Relaxed);
+        self.drain_frames()
+    }
+
+    /// Creates a snapshot of the handle's statistics.
+    #[must_use]
+    pub fn snapshot(&self) -> TelemetryHandleSnapshot {
+        TelemetryHandleSnapshot {
+            episode_id: self.episode_id.clone(),
+            pid: self.pid,
+            seq: self.seq(),
+            elapsed_ns: self.elapsed_ns(),
+            frames_collected: self.frames_collected(),
+            frames_promoted: self.frames_promoted(),
+            buffer_len: self.buffer_len(),
+            buffer_capacity: self.buffer_capacity(),
+            stopped: self.is_stopped(),
+            high_freq_active: self.is_high_freq_active(),
+        }
+    }
+}
+
+/// Snapshot of a telemetry handle's state.
+#[derive(Debug, Clone)]
+pub struct TelemetryHandleSnapshot {
+    /// Episode identifier.
+    pub episode_id: EpisodeId,
+
+    /// Process ID being monitored.
+    pub pid: Pid,
+
+    /// Current sequence number.
+    pub seq: u64,
+
+    /// Elapsed time in nanoseconds.
+    pub elapsed_ns: u64,
+
+    /// Total frames collected.
+    pub frames_collected: u64,
+
+    /// Total frames promoted.
+    pub frames_promoted: u64,
+
+    /// Current buffer length.
+    pub buffer_len: usize,
+
+    /// Buffer capacity.
+    pub buffer_capacity: usize,
+
+    /// Whether collection is stopped.
+    pub stopped: bool,
+
+    /// Whether high-frequency mode is active.
+    pub high_freq_active: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::telemetry::stats::{CpuStats, IoStats, MemoryStats, MetricSource};
+
+    fn test_episode_id() -> EpisodeId {
+        EpisodeId::new("test-episode-001").expect("valid episode ID")
+    }
+
+    fn test_stats() -> ResourceStats {
+        ResourceStats::new(
+            CpuStats::new(
+                1_000_000_000,
+                600_000_000,
+                400_000_000,
+                MetricSource::Cgroup,
+            ),
+            MemoryStats::new(104_857_600, 157_286_400, 10, 1000, MetricSource::Cgroup),
+            IoStats::new(1_048_576, 524_288, 100, 50, MetricSource::Cgroup),
+        )
+    }
+
+    // =========================================================================
+    // UT-00169-01: Frame collection tests
+    // =========================================================================
+
+    #[test]
+    fn test_telemetry_handle_new() {
+        let handle = TelemetryHandle::new(test_episode_id(), Pid::from_raw(1234), 100);
+
+        assert_eq!(handle.episode_id().as_str(), "test-episode-001");
+        assert_eq!(handle.pid().as_raw(), 1234);
+        assert_eq!(handle.seq(), 0);
+        assert!(!handle.is_stopped());
+        assert!(!handle.is_high_freq_active());
+        assert_eq!(handle.buffer_capacity(), 100);
+    }
+
+    #[test]
+    fn test_telemetry_handle_next_frame() {
+        let handle = TelemetryHandle::new(test_episode_id(), Pid::from_raw(1234), 100);
+
+        let frame = handle
+            .next_frame(test_stats(), O11yFlags::new().with_initial())
+            .expect("frame should be created");
+
+        assert_eq!(frame.seq(), 0);
+        assert!(frame.o11y_flags().initial);
+        assert_eq!(handle.seq(), 1);
+        assert_eq!(handle.frames_collected(), 1);
+        assert_eq!(handle.buffer_len(), 1);
+    }
+
+    #[test]
+    fn test_telemetry_handle_multiple_frames() {
+        let handle = TelemetryHandle::new(test_episode_id(), Pid::from_raw(1234), 100);
+
+        for i in 0..10 {
+            let frame = handle
+                .next_frame(test_stats(), O11yFlags::new())
+                .expect("frame should be created");
+            assert_eq!(frame.seq(), i);
+        }
+
+        assert_eq!(handle.seq(), 10);
+        assert_eq!(handle.frames_collected(), 10);
+        assert_eq!(handle.buffer_len(), 10);
+    }
+
+    #[test]
+    fn test_telemetry_handle_ring_buffer_overflow() {
+        let handle = TelemetryHandle::new(test_episode_id(), Pid::from_raw(1234), 5);
+
+        // Fill beyond capacity
+        for _ in 0..10 {
+            handle.next_frame(test_stats(), O11yFlags::new());
+        }
+
+        assert_eq!(handle.frames_collected(), 10);
+        assert_eq!(handle.buffer_len(), 5); // Capped at capacity
+
+        // Check that we have the most recent frames
+        let frames = handle.iter_frames();
+        assert_eq!(frames.len(), 5);
+        assert_eq!(frames[0].seq(), 5); // Oldest remaining
+        assert_eq!(frames[4].seq(), 9); // Newest
+    }
+
+    #[test]
+    fn test_telemetry_handle_stop() {
+        let handle = TelemetryHandle::new(test_episode_id(), Pid::from_raw(1234), 100);
+
+        handle.next_frame(test_stats(), O11yFlags::new());
+        handle.next_frame(test_stats(), O11yFlags::new());
+        handle.next_frame(test_stats(), O11yFlags::new());
+
+        let frames = handle.stop();
+        assert_eq!(frames.len(), 3);
+        assert!(handle.is_stopped());
+
+        // Further frames should fail
+        assert!(handle.next_frame(test_stats(), O11yFlags::new()).is_none());
+    }
+
+    #[test]
+    fn test_telemetry_handle_drain_frames() {
+        let handle = TelemetryHandle::new(test_episode_id(), Pid::from_raw(1234), 100);
+
+        for _ in 0..5 {
+            handle.next_frame(test_stats(), O11yFlags::new());
+        }
+
+        let frames = handle.drain_frames();
+        assert_eq!(frames.len(), 5);
+        assert_eq!(handle.buffer_len(), 0);
+        assert_eq!(handle.frames_promoted(), 5);
+    }
+
+    #[test]
+    fn test_telemetry_handle_high_freq_mode() {
+        let handle = TelemetryHandle::new(test_episode_id(), Pid::from_raw(1234), 100);
+
+        assert!(!handle.is_high_freq_active());
+
+        handle.set_high_freq_active(true);
+        assert!(handle.is_high_freq_active());
+
+        handle.set_high_freq_active(false);
+        assert!(!handle.is_high_freq_active());
+    }
+
+    #[test]
+    fn test_telemetry_handle_compute_delta() {
+        let handle = TelemetryHandle::new(test_episode_id(), Pid::from_raw(1234), 100);
+
+        let stats1 = ResourceStats::new(
+            CpuStats::new(
+                1_000_000_000,
+                600_000_000,
+                400_000_000,
+                MetricSource::Cgroup,
+            ),
+            MemoryStats::new(104_857_600, 157_286_400, 10, 1000, MetricSource::Cgroup),
+            IoStats::new(1_000_000, 500_000, 100, 50, MetricSource::Cgroup),
+        );
+
+        // First frame - no previous
+        let (cpu_delta, io_delta) = handle.compute_delta(&stats1);
+        assert_eq!(cpu_delta, 1_000_000_000);
+        assert_eq!(io_delta, 1_500_000);
+
+        // Record the first stats
+        handle.next_frame(stats1, O11yFlags::new());
+
+        // Second frame - compute delta from previous
+        let stats2 = ResourceStats::new(
+            CpuStats::new(
+                1_500_000_000,
+                900_000_000,
+                600_000_000,
+                MetricSource::Cgroup,
+            ),
+            MemoryStats::new(104_857_600, 157_286_400, 10, 1000, MetricSource::Cgroup),
+            IoStats::new(2_000_000, 1_000_000, 200, 100, MetricSource::Cgroup),
+        );
+
+        let (cpu_delta, io_delta) = handle.compute_delta(&stats2);
+        assert_eq!(cpu_delta, 500_000_000);
+        assert_eq!(io_delta, 1_500_000);
+    }
+
+    #[test]
+    fn test_telemetry_handle_snapshot() {
+        let handle = TelemetryHandle::new(test_episode_id(), Pid::from_raw(1234), 100);
+
+        handle.next_frame(test_stats(), O11yFlags::new());
+        handle.next_frame(test_stats(), O11yFlags::new());
+        handle.set_high_freq_active(true);
+
+        let snapshot = handle.snapshot();
+        assert_eq!(snapshot.episode_id.as_str(), "test-episode-001");
+        assert_eq!(snapshot.pid.as_raw(), 1234);
+        assert_eq!(snapshot.seq, 2);
+        assert_eq!(snapshot.frames_collected, 2);
+        assert_eq!(snapshot.buffer_len, 2);
+        assert_eq!(snapshot.buffer_capacity, 100);
+        assert!(!snapshot.stopped);
+        assert!(snapshot.high_freq_active);
+    }
+
+    #[test]
+    fn test_telemetry_handle_iter_frames() {
+        let handle = TelemetryHandle::new(test_episode_id(), Pid::from_raw(1234), 100);
+
+        for _ in 0..5 {
+            handle.next_frame(test_stats(), O11yFlags::new());
+        }
+
+        let frames = handle.iter_frames();
+        assert_eq!(frames.len(), 5);
+
+        // iter_frames should not drain
+        assert_eq!(handle.buffer_len(), 5);
+    }
+}

--- a/crates/apm2-daemon/src/telemetry/mod.rs
+++ b/crates/apm2-daemon/src/telemetry/mod.rs
@@ -5,7 +5,8 @@
 //!
 //! # Architecture
 //!
-//! Per AD-TEL-001, telemetry is collected from two possible sources:
+//! Per AD-TEL-001 and CTR-DAEMON-005, telemetry is collected from two
+//! possible sources:
 //!
 //! - **Primary**: cgroups v2 hierarchy
 //!   (`/sys/fs/cgroup/apm2.slice/episode-{uuid}.scope/`)
@@ -14,6 +15,11 @@
 //! The collection architecture follows a layered design:
 //!
 //! ```text
+//! +-------------------+
+//! |TelemetryCollector |  <-- Main collector with policy and ring buffer
+//! +-------------------+
+//!          |
+//!          v
 //! +-------------------+
 //! |   CgroupReader    |  <-- Primary reader for per-episode cgroups
 //! +-------------------+
@@ -25,7 +31,7 @@
 //!          |
 //!          v
 //! +-------------------+
-//! |  ResourceStats    |  <-- Unified stats with source tracking
+//! |  TelemetryFrame   |  <-- Captured metrics with timestamps
 //! +-------------------+
 //! ```
 //!
@@ -34,34 +40,60 @@
 //! - [`cgroup`]: Cgroups v2 reader and cgroup path resolution
 //! - [`stats`]: CPU, memory, and I/O statistics types
 //! - [`proc_fallback`]: `/proc` fallback for degraded mode
+//! - [`frame`]: `TelemetryFrame` type for captured metrics
+//! - [`policy`]: `TelemetryPolicy` configuration
+//! - [`handle`]: `TelemetryHandle` for active collection sessions
+//! - [`collector`]: `TelemetryCollector` implementation
 //!
 //! # Usage
 //!
 //! ```rust,ignore
-//! use apm2_daemon::telemetry::{CgroupReader, ResourceStats};
+//! use apm2_daemon::telemetry::{
+//!     CgroupReader, TelemetryCollector, TelemetryPolicy, TelemetryFrame
+//! };
+//! use apm2_daemon::episode::EpisodeId;
+//! use nix::unistd::Pid;
 //!
-//! // Create reader for an episode cgroup
+//! // Create collector with policy
+//! let policy = TelemetryPolicy::default();
+//! let collector = TelemetryCollector::new(policy);
+//!
+//! // Start collection for an episode
+//! let handle = collector.start(
+//!     EpisodeId::new("ep-abc123")?,
+//!     Pid::from_raw(1234),
+//! );
+//!
+//! // Create reader for the episode cgroup
 //! let reader = CgroupReader::for_episode("ep-abc123")?;
 //!
-//! // Read all resource stats
-//! let stats: ResourceStats = reader.read_all();
+//! // Collect a frame
+//! let frame = collector.collect(&handle, &reader, O11yFlags::new())?;
 //!
 //! // Check if we're in degraded mode
-//! if stats.has_degraded_source() {
+//! if frame.is_degraded() {
 //!     warn!("Telemetry accuracy reduced - using /proc fallback");
 //! }
+//!
+//! // Stop collection and get final frames
+//! let frames = handle.stop();
 //! ```
 //!
 //! # Contract References
 //!
 //! - AD-TEL-001: Telemetry collection via cgroups v2
 //! - AD-CGROUP-001: Per-episode cgroup hierarchy
+//! - CTR-DAEMON-005: `TelemetryCollector` and frame streaming
 
 pub mod cgroup;
+pub mod collector;
+pub mod frame;
+pub mod handle;
+pub mod policy;
 pub mod proc_fallback;
 pub mod stats;
 
-// Re-export primary types
+// Re-export cgroup types
 pub use cgroup::{
     APM2_SLICE, CGROUP_V2_MOUNT, CgroupError, CgroupReader, CgroupResult, MAX_CGROUP_PATH_LEN,
     MAX_EPISODE_ID_LEN, MAX_TELEMETRY_FILE_SIZE, OsResourceLimits, ScopeCreationResult,
@@ -69,7 +101,18 @@ pub use cgroup::{
     episode_cgroup_path, episode_cgroup_path_with_root, is_cgroup_v2_available,
     is_cgroup_v2_available_at, remove_episode_scope, remove_episode_scope_with_root,
 };
+// Re-export collector types (TCK-00169)
+pub use collector::{TelemetryCollector, TelemetryError, TelemetryResult, new_shared_collector};
+pub use frame::{MAX_FRAME_BYTES, MAX_FRAME_NS, O11yFlags, TelemetryFrame, TelemetryFrameBuilder};
+pub use handle::{MAX_SEQUENCE, TelemetryHandle, TelemetryHandleSnapshot};
+pub use policy::{
+    DEFAULT_HIGH_FREQ_THRESHOLD_PERCENT, DEFAULT_RING_BUFFER_CAPACITY, DEFAULT_SAMPLE_PERIOD_MS,
+    HIGH_FREQ_MULTIPLIER, MAX_RING_BUFFER_CAPACITY, MAX_SAMPLE_PERIOD_MS, MIN_RING_BUFFER_CAPACITY,
+    MIN_SAMPLE_PERIOD_MS, PromoteTriggers, TelemetryPolicy, TelemetryPolicyBuilder,
+};
+// Re-export proc fallback types
 pub use proc_fallback::{MAX_PROC_FILE_SIZE, ProcError, ProcReader, ProcResult};
+// Re-export stats types
 pub use stats::{
     CpuStats, IoStats, MAX_BYTES, MAX_NS, MAX_OPS, MAX_PAGE_FAULTS, MemoryStats, MetricSource,
     ResourceStats,

--- a/crates/apm2-daemon/src/telemetry/policy.rs
+++ b/crates/apm2-daemon/src/telemetry/policy.rs
@@ -1,0 +1,666 @@
+//! Telemetry policy configuration.
+//!
+//! This module defines the `TelemetryPolicy` type per CTR-DAEMON-005,
+//! configuring how telemetry is collected and persisted.
+//!
+//! # Architecture
+//!
+//! ```text
+//! TelemetryPolicy
+//!     |
+//!     +-- sample_period_ms: collection interval
+//!     +-- promote_triggers: when to persist full buffer
+//!     +-- ring_buffer_capacity: size of frame buffer
+//!     +-- high_frequency_threshold: when to switch to high-freq mode
+//! ```
+//!
+//! # Security Considerations
+//!
+//! - All limits are bounded to prevent resource exhaustion
+//! - Minimum sample period prevents denial-of-service via excessive collection
+//! - Maximum buffer capacity prevents memory exhaustion
+//!
+//! # Contract References
+//!
+//! - CTR-DAEMON-005: `TelemetryCollector` and frame streaming
+
+use serde::{Deserialize, Serialize};
+
+use crate::episode::RiskTier;
+
+/// Minimum sample period in milliseconds (100ms = 10 Hz max).
+///
+/// This prevents denial-of-service via excessive collection frequency.
+pub const MIN_SAMPLE_PERIOD_MS: u64 = 100;
+
+/// Maximum sample period in milliseconds (1 hour).
+pub const MAX_SAMPLE_PERIOD_MS: u64 = 3_600_000;
+
+/// Default sample period in milliseconds (1 second).
+pub const DEFAULT_SAMPLE_PERIOD_MS: u64 = 1_000;
+
+/// Minimum ring buffer capacity (must hold at least 1 frame).
+pub const MIN_RING_BUFFER_CAPACITY: usize = 1;
+
+/// Maximum ring buffer capacity (prevents memory exhaustion).
+pub const MAX_RING_BUFFER_CAPACITY: usize = 10_000;
+
+/// Default ring buffer capacity (1024 frames).
+pub const DEFAULT_RING_BUFFER_CAPACITY: usize = 1024;
+
+/// Default high-frequency threshold (80% of budget consumed).
+pub const DEFAULT_HIGH_FREQ_THRESHOLD_PERCENT: u8 = 80;
+
+/// High-frequency sample period multiplier (4x faster).
+pub const HIGH_FREQ_MULTIPLIER: u64 = 4;
+
+/// Triggers that cause the ring buffer to be promoted to persistent storage.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromoteTriggers {
+    /// Promote on episode termination.
+    pub on_termination: bool,
+
+    /// Promote on quarantine (abnormal termination).
+    pub on_quarantine: bool,
+
+    /// Promote when budget threshold is exceeded.
+    pub on_budget_threshold: bool,
+
+    /// Promote periodically (every N frames).
+    pub periodic_frames: Option<u64>,
+}
+
+impl PromoteTriggers {
+    /// Creates default triggers (promote on termination and quarantine).
+    #[must_use]
+    pub const fn default_triggers() -> Self {
+        Self {
+            on_termination: true,
+            on_quarantine: true,
+            on_budget_threshold: false,
+            periodic_frames: None,
+        }
+    }
+
+    /// Creates triggers that promote on all events.
+    #[must_use]
+    pub const fn all() -> Self {
+        Self {
+            on_termination: true,
+            on_quarantine: true,
+            on_budget_threshold: true,
+            periodic_frames: Some(100),
+        }
+    }
+
+    /// Creates triggers that never promote.
+    #[must_use]
+    pub const fn none() -> Self {
+        Self {
+            on_termination: false,
+            on_quarantine: false,
+            on_budget_threshold: false,
+            periodic_frames: None,
+        }
+    }
+
+    /// Sets the `on_termination` flag.
+    #[must_use]
+    pub const fn with_on_termination(mut self, value: bool) -> Self {
+        self.on_termination = value;
+        self
+    }
+
+    /// Sets the `on_quarantine` flag.
+    #[must_use]
+    pub const fn with_on_quarantine(mut self, value: bool) -> Self {
+        self.on_quarantine = value;
+        self
+    }
+
+    /// Sets the `on_budget_threshold` flag.
+    #[must_use]
+    pub const fn with_on_budget_threshold(mut self, value: bool) -> Self {
+        self.on_budget_threshold = value;
+        self
+    }
+
+    /// Sets the periodic frame count.
+    #[must_use]
+    pub const fn with_periodic_frames(mut self, frames: u64) -> Self {
+        self.periodic_frames = Some(frames);
+        self
+    }
+
+    /// Returns `true` if any trigger is enabled.
+    #[must_use]
+    pub const fn has_any(&self) -> bool {
+        self.on_termination
+            || self.on_quarantine
+            || self.on_budget_threshold
+            || self.periodic_frames.is_some()
+    }
+}
+
+/// Telemetry collection policy configuration.
+///
+/// Per CTR-DAEMON-005, this configures:
+/// - Sample period (how often to collect)
+/// - Ring buffer capacity (how many frames to retain)
+/// - Promote triggers (when to persist to storage)
+/// - High-frequency mode threshold (when to speed up collection)
+///
+/// # Example
+///
+/// ```rust
+/// use apm2_daemon::telemetry::{PromoteTriggers, TelemetryPolicy};
+///
+/// let policy = TelemetryPolicy::builder()
+///     .sample_period_ms(500)
+///     .ring_buffer_capacity(2048)
+///     .promote_triggers(PromoteTriggers::default_triggers())
+///     .build();
+///
+/// assert_eq!(policy.sample_period_ms(), 500);
+/// assert_eq!(policy.ring_buffer_capacity(), 2048);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TelemetryPolicy {
+    /// Sample period in milliseconds.
+    sample_period_ms: u64,
+
+    /// Ring buffer capacity (number of frames).
+    ring_buffer_capacity: usize,
+
+    /// Triggers for promoting buffer to persistent storage.
+    promote_triggers: PromoteTriggers,
+
+    /// Threshold (percent of budget consumed) to switch to high-frequency mode.
+    high_freq_threshold_percent: u8,
+
+    /// Whether high-frequency mode is enabled.
+    high_freq_enabled: bool,
+}
+
+impl TelemetryPolicy {
+    /// Creates a new policy builder.
+    #[must_use]
+    pub const fn builder() -> TelemetryPolicyBuilder {
+        TelemetryPolicyBuilder::new()
+    }
+
+    /// Creates a policy with invariant validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string if any value is out of bounds.
+    pub fn try_new(
+        sample_period_ms: u64,
+        ring_buffer_capacity: usize,
+        promote_triggers: PromoteTriggers,
+        high_freq_threshold_percent: u8,
+        high_freq_enabled: bool,
+    ) -> Result<Self, String> {
+        let policy = Self {
+            sample_period_ms: clamp_sample_period(sample_period_ms),
+            ring_buffer_capacity: clamp_buffer_capacity(ring_buffer_capacity),
+            promote_triggers,
+            high_freq_threshold_percent: clamp_threshold(high_freq_threshold_percent),
+            high_freq_enabled,
+        };
+        policy.validate()?;
+        Ok(policy)
+    }
+
+    /// Validates policy invariants.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string if any invariant is violated.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.sample_period_ms < MIN_SAMPLE_PERIOD_MS {
+            return Err(format!(
+                "sample_period_ms ({}) below minimum ({})",
+                self.sample_period_ms, MIN_SAMPLE_PERIOD_MS
+            ));
+        }
+        if self.sample_period_ms > MAX_SAMPLE_PERIOD_MS {
+            return Err(format!(
+                "sample_period_ms ({}) above maximum ({})",
+                self.sample_period_ms, MAX_SAMPLE_PERIOD_MS
+            ));
+        }
+        if self.ring_buffer_capacity < MIN_RING_BUFFER_CAPACITY {
+            return Err(format!(
+                "ring_buffer_capacity ({}) below minimum ({})",
+                self.ring_buffer_capacity, MIN_RING_BUFFER_CAPACITY
+            ));
+        }
+        if self.ring_buffer_capacity > MAX_RING_BUFFER_CAPACITY {
+            return Err(format!(
+                "ring_buffer_capacity ({}) above maximum ({})",
+                self.ring_buffer_capacity, MAX_RING_BUFFER_CAPACITY
+            ));
+        }
+        if self.high_freq_threshold_percent > 100 {
+            return Err(format!(
+                "high_freq_threshold_percent ({}) above 100",
+                self.high_freq_threshold_percent
+            ));
+        }
+        Ok(())
+    }
+
+    /// Creates a default policy for a given risk tier.
+    ///
+    /// Higher risk tiers get more frequent sampling and larger buffers.
+    #[must_use]
+    pub const fn for_risk_tier(tier: RiskTier) -> Self {
+        match tier {
+            RiskTier::Tier0 => Self {
+                sample_period_ms: 5_000, // 5 seconds
+                ring_buffer_capacity: 64,
+                promote_triggers: PromoteTriggers::none(),
+                high_freq_threshold_percent: 90,
+                high_freq_enabled: false,
+            },
+            RiskTier::Tier1 => Self {
+                sample_period_ms: 2_000, // 2 seconds
+                ring_buffer_capacity: 256,
+                promote_triggers: PromoteTriggers::default_triggers(),
+                high_freq_threshold_percent: 85,
+                high_freq_enabled: true,
+            },
+            RiskTier::Tier2 => Self {
+                sample_period_ms: 1_000, // 1 second
+                ring_buffer_capacity: 512,
+                promote_triggers: PromoteTriggers::default_triggers(),
+                high_freq_threshold_percent: 80,
+                high_freq_enabled: true,
+            },
+            RiskTier::Tier3 | RiskTier::Tier4 => Self {
+                sample_period_ms: 500, // 500ms
+                ring_buffer_capacity: 1024,
+                promote_triggers: PromoteTriggers::all(),
+                high_freq_threshold_percent: 75,
+                high_freq_enabled: true,
+            },
+        }
+    }
+
+    // =========================================================================
+    // Accessors
+    // =========================================================================
+
+    /// Returns the sample period in milliseconds.
+    #[must_use]
+    pub const fn sample_period_ms(&self) -> u64 {
+        self.sample_period_ms
+    }
+
+    /// Returns the ring buffer capacity.
+    #[must_use]
+    pub const fn ring_buffer_capacity(&self) -> usize {
+        self.ring_buffer_capacity
+    }
+
+    /// Returns the promote triggers.
+    #[must_use]
+    pub const fn promote_triggers(&self) -> &PromoteTriggers {
+        &self.promote_triggers
+    }
+
+    /// Returns the high-frequency threshold percent.
+    #[must_use]
+    pub const fn high_freq_threshold_percent(&self) -> u8 {
+        self.high_freq_threshold_percent
+    }
+
+    /// Returns whether high-frequency mode is enabled.
+    #[must_use]
+    pub const fn high_freq_enabled(&self) -> bool {
+        self.high_freq_enabled
+    }
+
+    /// Returns the high-frequency sample period (faster collection).
+    #[must_use]
+    pub const fn high_freq_sample_period_ms(&self) -> u64 {
+        let period = self.sample_period_ms / HIGH_FREQ_MULTIPLIER;
+        if period < MIN_SAMPLE_PERIOD_MS {
+            MIN_SAMPLE_PERIOD_MS
+        } else {
+            period
+        }
+    }
+
+    /// Returns the effective sample period based on whether high-frequency
+    /// mode is active.
+    #[must_use]
+    pub const fn effective_sample_period_ms(&self, high_freq_active: bool) -> u64 {
+        if high_freq_active && self.high_freq_enabled {
+            self.high_freq_sample_period_ms()
+        } else {
+            self.sample_period_ms
+        }
+    }
+}
+
+impl Default for TelemetryPolicy {
+    fn default() -> Self {
+        Self {
+            sample_period_ms: DEFAULT_SAMPLE_PERIOD_MS,
+            ring_buffer_capacity: DEFAULT_RING_BUFFER_CAPACITY,
+            promote_triggers: PromoteTriggers::default_triggers(),
+            high_freq_threshold_percent: DEFAULT_HIGH_FREQ_THRESHOLD_PERCENT,
+            high_freq_enabled: true,
+        }
+    }
+}
+
+/// Builder for [`TelemetryPolicy`].
+#[derive(Debug, Clone)]
+pub struct TelemetryPolicyBuilder {
+    sample_period_ms: u64,
+    ring_buffer_capacity: usize,
+    promote_triggers: PromoteTriggers,
+    high_freq_threshold_percent: u8,
+    high_freq_enabled: bool,
+}
+
+impl TelemetryPolicyBuilder {
+    /// Creates a new builder with default values.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            sample_period_ms: DEFAULT_SAMPLE_PERIOD_MS,
+            ring_buffer_capacity: DEFAULT_RING_BUFFER_CAPACITY,
+            promote_triggers: PromoteTriggers::default_triggers(),
+            high_freq_threshold_percent: DEFAULT_HIGH_FREQ_THRESHOLD_PERCENT,
+            high_freq_enabled: true,
+        }
+    }
+
+    /// Sets the sample period in milliseconds.
+    #[must_use]
+    pub const fn sample_period_ms(mut self, ms: u64) -> Self {
+        self.sample_period_ms = ms;
+        self
+    }
+
+    /// Sets the ring buffer capacity.
+    #[must_use]
+    pub const fn ring_buffer_capacity(mut self, capacity: usize) -> Self {
+        self.ring_buffer_capacity = capacity;
+        self
+    }
+
+    /// Sets the promote triggers.
+    #[must_use]
+    pub const fn promote_triggers(mut self, triggers: PromoteTriggers) -> Self {
+        self.promote_triggers = triggers;
+        self
+    }
+
+    /// Sets the high-frequency threshold percent.
+    #[must_use]
+    pub const fn high_freq_threshold_percent(mut self, percent: u8) -> Self {
+        self.high_freq_threshold_percent = percent;
+        self
+    }
+
+    /// Sets whether high-frequency mode is enabled.
+    #[must_use]
+    pub const fn high_freq_enabled(mut self, enabled: bool) -> Self {
+        self.high_freq_enabled = enabled;
+        self
+    }
+
+    /// Builds the policy with clamping.
+    #[must_use]
+    pub const fn build(self) -> TelemetryPolicy {
+        TelemetryPolicy {
+            sample_period_ms: clamp_sample_period(self.sample_period_ms),
+            ring_buffer_capacity: clamp_buffer_capacity(self.ring_buffer_capacity),
+            promote_triggers: self.promote_triggers,
+            high_freq_threshold_percent: clamp_threshold(self.high_freq_threshold_percent),
+            high_freq_enabled: self.high_freq_enabled,
+        }
+    }
+
+    /// Builds the policy with validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string if any invariant is violated.
+    pub fn try_build(self) -> Result<TelemetryPolicy, String> {
+        let policy = self.build();
+        policy.validate()?;
+        Ok(policy)
+    }
+}
+
+impl Default for TelemetryPolicyBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Clamps sample period to valid range.
+const fn clamp_sample_period(ms: u64) -> u64 {
+    if ms < MIN_SAMPLE_PERIOD_MS {
+        MIN_SAMPLE_PERIOD_MS
+    } else if ms > MAX_SAMPLE_PERIOD_MS {
+        MAX_SAMPLE_PERIOD_MS
+    } else {
+        ms
+    }
+}
+
+/// Clamps buffer capacity to valid range.
+const fn clamp_buffer_capacity(capacity: usize) -> usize {
+    if capacity < MIN_RING_BUFFER_CAPACITY {
+        MIN_RING_BUFFER_CAPACITY
+    } else if capacity > MAX_RING_BUFFER_CAPACITY {
+        MAX_RING_BUFFER_CAPACITY
+    } else {
+        capacity
+    }
+}
+
+/// Clamps threshold to 0-100 range.
+const fn clamp_threshold(percent: u8) -> u8 {
+    if percent > 100 { 100 } else { percent }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // TelemetryPolicy tests
+    // =========================================================================
+
+    #[test]
+    fn test_telemetry_policy_default() {
+        let policy = TelemetryPolicy::default();
+        assert_eq!(policy.sample_period_ms(), DEFAULT_SAMPLE_PERIOD_MS);
+        assert_eq!(policy.ring_buffer_capacity(), DEFAULT_RING_BUFFER_CAPACITY);
+        assert!(policy.high_freq_enabled());
+    }
+
+    #[test]
+    fn test_telemetry_policy_builder() {
+        let policy = TelemetryPolicy::builder()
+            .sample_period_ms(500)
+            .ring_buffer_capacity(2048)
+            .high_freq_threshold_percent(75)
+            .high_freq_enabled(true)
+            .build();
+
+        assert_eq!(policy.sample_period_ms(), 500);
+        assert_eq!(policy.ring_buffer_capacity(), 2048);
+        assert_eq!(policy.high_freq_threshold_percent(), 75);
+        assert!(policy.high_freq_enabled());
+    }
+
+    #[test]
+    fn test_telemetry_policy_clamping() {
+        // Test lower bound clamping
+        let policy = TelemetryPolicy::builder()
+            .sample_period_ms(10) // Below minimum
+            .ring_buffer_capacity(0) // Below minimum
+            .high_freq_threshold_percent(150) // Above 100
+            .build();
+
+        assert_eq!(policy.sample_period_ms(), MIN_SAMPLE_PERIOD_MS);
+        assert_eq!(policy.ring_buffer_capacity(), MIN_RING_BUFFER_CAPACITY);
+        assert_eq!(policy.high_freq_threshold_percent(), 100);
+
+        // Test upper bound clamping
+        let policy = TelemetryPolicy::builder()
+            .sample_period_ms(10_000_000) // Above maximum
+            .ring_buffer_capacity(100_000) // Above maximum
+            .build();
+
+        assert_eq!(policy.sample_period_ms(), MAX_SAMPLE_PERIOD_MS);
+        assert_eq!(policy.ring_buffer_capacity(), MAX_RING_BUFFER_CAPACITY);
+    }
+
+    #[test]
+    fn test_telemetry_policy_try_new() {
+        let result =
+            TelemetryPolicy::try_new(1000, 512, PromoteTriggers::default_triggers(), 80, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_telemetry_policy_for_risk_tier() {
+        let tier0 = TelemetryPolicy::for_risk_tier(RiskTier::Tier0);
+        assert_eq!(tier0.sample_period_ms(), 5_000);
+        assert!(!tier0.high_freq_enabled());
+
+        let tier1 = TelemetryPolicy::for_risk_tier(RiskTier::Tier1);
+        assert_eq!(tier1.sample_period_ms(), 2_000);
+        assert!(tier1.high_freq_enabled());
+
+        let tier2 = TelemetryPolicy::for_risk_tier(RiskTier::Tier2);
+        assert_eq!(tier2.sample_period_ms(), 1_000);
+
+        let tier3 = TelemetryPolicy::for_risk_tier(RiskTier::Tier3);
+        assert_eq!(tier3.sample_period_ms(), 500);
+        assert_eq!(tier3.ring_buffer_capacity(), 1024);
+    }
+
+    #[test]
+    fn test_telemetry_policy_high_freq_sample_period() {
+        let policy = TelemetryPolicy::builder().sample_period_ms(1000).build();
+
+        assert_eq!(policy.high_freq_sample_period_ms(), 250);
+    }
+
+    #[test]
+    fn test_telemetry_policy_high_freq_sample_period_clamped() {
+        let policy = TelemetryPolicy::builder()
+            .sample_period_ms(200) // Would be 50ms at high freq, below min
+            .build();
+
+        assert_eq!(policy.high_freq_sample_period_ms(), MIN_SAMPLE_PERIOD_MS);
+    }
+
+    #[test]
+    fn test_telemetry_policy_effective_sample_period() {
+        let policy = TelemetryPolicy::builder()
+            .sample_period_ms(1000)
+            .high_freq_enabled(true)
+            .build();
+
+        assert_eq!(policy.effective_sample_period_ms(false), 1000);
+        assert_eq!(policy.effective_sample_period_ms(true), 250);
+    }
+
+    #[test]
+    fn test_telemetry_policy_effective_sample_period_disabled() {
+        let policy = TelemetryPolicy::builder()
+            .sample_period_ms(1000)
+            .high_freq_enabled(false)
+            .build();
+
+        assert_eq!(policy.effective_sample_period_ms(false), 1000);
+        assert_eq!(policy.effective_sample_period_ms(true), 1000); // Still normal period
+    }
+
+    // =========================================================================
+    // PromoteTriggers tests
+    // =========================================================================
+
+    #[test]
+    fn test_promote_triggers_default() {
+        let triggers = PromoteTriggers::default_triggers();
+        assert!(triggers.on_termination);
+        assert!(triggers.on_quarantine);
+        assert!(!triggers.on_budget_threshold);
+        assert!(triggers.periodic_frames.is_none());
+        assert!(triggers.has_any());
+    }
+
+    #[test]
+    fn test_promote_triggers_all() {
+        let triggers = PromoteTriggers::all();
+        assert!(triggers.on_termination);
+        assert!(triggers.on_quarantine);
+        assert!(triggers.on_budget_threshold);
+        assert_eq!(triggers.periodic_frames, Some(100));
+        assert!(triggers.has_any());
+    }
+
+    #[test]
+    fn test_promote_triggers_none() {
+        let triggers = PromoteTriggers::none();
+        assert!(!triggers.on_termination);
+        assert!(!triggers.on_quarantine);
+        assert!(!triggers.on_budget_threshold);
+        assert!(triggers.periodic_frames.is_none());
+        assert!(!triggers.has_any());
+    }
+
+    #[test]
+    fn test_promote_triggers_builder_methods() {
+        let triggers = PromoteTriggers::none()
+            .with_on_termination(true)
+            .with_on_quarantine(true)
+            .with_on_budget_threshold(true)
+            .with_periodic_frames(50);
+
+        assert!(triggers.on_termination);
+        assert!(triggers.on_quarantine);
+        assert!(triggers.on_budget_threshold);
+        assert_eq!(triggers.periodic_frames, Some(50));
+    }
+
+    // =========================================================================
+    // Serialization tests
+    // =========================================================================
+
+    #[test]
+    fn test_telemetry_policy_serialize() {
+        let policy = TelemetryPolicy::builder()
+            .sample_period_ms(500)
+            .ring_buffer_capacity(256)
+            .build();
+
+        let json = serde_json::to_string(&policy).expect("serialize failed");
+        let decoded: TelemetryPolicy = serde_json::from_str(&json).expect("deserialize failed");
+
+        assert_eq!(policy, decoded);
+    }
+
+    #[test]
+    fn test_promote_triggers_serialize() {
+        let triggers = PromoteTriggers::all();
+        let json = serde_json::to_string(&triggers).expect("serialize failed");
+        let decoded: PromoteTriggers = serde_json::from_str(&json).expect("deserialize failed");
+        assert_eq!(triggers, decoded);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement TelemetryFrame type with episode_id, seq, ts_mono, cpu/mem/io metrics, and O11yFlags for sampling mode
- Implement TelemetryHandle for active collection with ring buffer, sequence generation, delta computation, and high-frequency mode support
- Implement TelemetryPolicy configuration for sample period, buffer capacity, promote triggers, and high-frequency thresholds
- Implement TelemetryCollector with start(), collect(), apply_policy(), and spawn_collection_loop() for async collection

## Key Features
- Configurable sample intervals with automatic high-frequency mode when budget nearing exhaustion
- Ring buffer storage for recent frames with bounded capacity per policy
- Budget integration for CPU and I/O tracking with automatic enforcement
- Async collection loop with budget exhaustion detection
- Support for degraded mode (proc fallback) with O11yFlags marking

## Contract References
- CTR-DAEMON-005: TelemetryCollector and frame streaming
- AD-TEL-001: Telemetry collection via cgroups v2

## Test plan
- [x] UT-00169-01: Frame collection tests pass (117 telemetry tests)
- [x] Budget integration tests verify CPU/IO tracking
- [x] clippy and fmt checks pass

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>