### PR TITLE
feat(TCK-00170): implement flight recorder with ring buffers

### DIFF
--- a/crates/apm2-daemon/src/evidence/config.rs
+++ b/crates/apm2-daemon/src/evidence/config.rs
@@ -1,0 +1,566 @@
+//! Recorder configuration per risk tier.
+//!
+//! This module defines `RecorderConfig` per AD-EVID-001, providing
+//! per-risk-tier buffer sizes for the flight recorder. Buffer sizes
+//! are specified in **item counts** (not bytes) because `RingBuffer<T>`
+//! operates on item capacity.
+//!
+//! # Architecture
+//!
+//! ```text
+//! RecorderConfig
+//!     |
+//!     +-- pty_capacity: usize
+//!     +-- tool_capacity: usize
+//!     +-- telemetry_capacity: usize
+//!     |
+//!     +-- from_risk_tier(RiskTier) -> RecorderConfig
+//! ```
+//!
+//! # Buffer Size Rationale (AD-EVID-001)
+//!
+//! Buffer capacities are derived from byte targets and estimated item sizes:
+//!
+//! | Tier    | PTY Target | Tool Target | Telemetry Target |
+//! |---------|-----------|-------------|------------------|
+//! | Tier 1  | ~1MB      | ~512KB      | ~256KB           |
+//! | Tier 2  | ~4MB      | ~2MB        | ~1MB             |
+//! | Tier 3+ | ~16MB     | ~8MB        | ~4MB             |
+//!
+//! Estimated average item sizes:
+//! - PTY output: ~4KB per chunk (typical terminal output)
+//! - Tool event: ~2KB per event (JSON-encoded request/response)
+//! - Telemetry frame: ~256 bytes (metrics struct)
+//!
+//! # Aggregate Memory Bounds
+//!
+//! With `MAX_CONCURRENT_EPISODES` = 10,000:
+//! - Tier 1: ~1.75MB per episode * 10,000 = ~17GB worst case
+//! - Tier 2: ~7MB per episode * 10,000 = ~70GB worst case
+//! - Tier 3+: ~28MB per episode * 10,000 = ~280GB worst case
+//!
+//! In practice, episodes are distributed across tiers and memory is reclaimed
+//! on normal termination. Only failure cases retain buffers until persistence.
+//!
+//! # Invariants
+//!
+//! - [INV-RC001] All capacities are > 0 (enforced by `try_new`)
+//! - [INV-RC002] Tier 0 uses minimal capacity (tier 1 values)
+//! - [INV-RC003] Higher tiers never have smaller buffers than lower tiers
+//!
+//! # Contract References
+//!
+//! - AD-EVID-001: Flight recorder and ring buffers
+//! - CTR-1303: Bounded collections with MAX_* constants
+
+use serde::{Deserialize, Serialize};
+
+use crate::episode::envelope::RiskTier;
+
+// =============================================================================
+// Capacity Constants (Item Counts)
+// =============================================================================
+
+/// Estimated average PTY chunk size (4KB).
+pub const ESTIMATED_PTY_CHUNK_SIZE: usize = 4 * 1024;
+
+/// Estimated average tool event size (2KB).
+pub const ESTIMATED_TOOL_EVENT_SIZE: usize = 2 * 1024;
+
+/// Estimated average telemetry frame size (256 bytes).
+pub const ESTIMATED_TELEMETRY_FRAME_SIZE: usize = 256;
+
+// Tier 1 capacities (derived from byte targets)
+// PTY: 1MB / 4KB = 256 items
+// Tool: 512KB / 2KB = 256 items
+// Telemetry: 256KB / 256B = 1024 items
+
+/// Tier 1 PTY buffer capacity (item count, ~1MB equivalent).
+pub const TIER_1_PTY_CAPACITY: usize = 256;
+
+/// Tier 1 tool buffer capacity (item count, ~512KB equivalent).
+pub const TIER_1_TOOL_CAPACITY: usize = 256;
+
+/// Tier 1 telemetry buffer capacity (item count, ~256KB equivalent).
+pub const TIER_1_TELEMETRY_CAPACITY: usize = 1024;
+
+// Tier 2 capacities (4x Tier 1)
+// PTY: 4MB / 4KB = 1024 items
+// Tool: 2MB / 2KB = 1024 items
+// Telemetry: 1MB / 256B = 4096 items
+
+/// Tier 2 PTY buffer capacity (item count, ~4MB equivalent).
+pub const TIER_2_PTY_CAPACITY: usize = 1024;
+
+/// Tier 2 tool buffer capacity (item count, ~2MB equivalent).
+pub const TIER_2_TOOL_CAPACITY: usize = 1024;
+
+/// Tier 2 telemetry buffer capacity (item count, ~1MB equivalent).
+pub const TIER_2_TELEMETRY_CAPACITY: usize = 4096;
+
+// Tier 3+ capacities (4x Tier 2)
+// PTY: 16MB / 4KB = 4096 items
+// Tool: 8MB / 2KB = 4096 items
+// Telemetry: 4MB / 256B = 16384 items
+
+/// Tier 3+ PTY buffer capacity (item count, ~16MB equivalent).
+pub const TIER_3_PLUS_PTY_CAPACITY: usize = 4096;
+
+/// Tier 3+ tool buffer capacity (item count, ~8MB equivalent).
+pub const TIER_3_PLUS_TOOL_CAPACITY: usize = 4096;
+
+/// Tier 3+ telemetry buffer capacity (item count, ~4MB equivalent).
+pub const TIER_3_PLUS_TELEMETRY_CAPACITY: usize = 16384;
+
+/// Maximum allowed capacity for any buffer (bounds memory growth).
+pub const MAX_BUFFER_CAPACITY: usize = 65536;
+
+/// Minimum allowed capacity for any buffer.
+pub const MIN_BUFFER_CAPACITY: usize = 1;
+
+// =============================================================================
+// RecorderConfig
+// =============================================================================
+
+/// Configuration for flight recorder buffer sizes.
+///
+/// All capacities are in **item counts**, not bytes. The `RingBuffer<T>` uses
+/// item-based capacity, and actual memory usage depends on item size.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use apm2_daemon::evidence::config::RecorderConfig;
+/// use apm2_daemon::episode::envelope::RiskTier;
+///
+/// // Get configuration for risk tier 2
+/// let config = RecorderConfig::from_risk_tier(RiskTier::Tier2);
+///
+/// assert_eq!(config.pty_capacity(), 1024);
+/// assert_eq!(config.tool_capacity(), 1024);
+/// assert_eq!(config.telemetry_capacity(), 4096);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::struct_field_names)] // Capacity suffix is intentional for clarity
+pub struct RecorderConfig {
+    /// PTY output buffer capacity (item count).
+    pty_capacity: usize,
+
+    /// Tool event buffer capacity (item count).
+    tool_capacity: usize,
+
+    /// Telemetry frame buffer capacity (item count).
+    telemetry_capacity: usize,
+}
+
+impl RecorderConfig {
+    /// Creates a new configuration with validated capacities.
+    ///
+    /// # Arguments
+    ///
+    /// * `pty_capacity` - PTY output buffer capacity
+    /// * `tool_capacity` - Tool event buffer capacity
+    /// * `telemetry_capacity` - Telemetry frame buffer capacity
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string if any capacity is 0 or exceeds
+    /// `MAX_BUFFER_CAPACITY`.
+    pub fn try_new(
+        pty_capacity: usize,
+        tool_capacity: usize,
+        telemetry_capacity: usize,
+    ) -> Result<Self, String> {
+        // INV-RC001: All capacities must be > 0
+        if pty_capacity < MIN_BUFFER_CAPACITY {
+            return Err(format!(
+                "INV-RC001 violated: pty_capacity ({pty_capacity}) must be >= {MIN_BUFFER_CAPACITY}"
+            ));
+        }
+        if tool_capacity < MIN_BUFFER_CAPACITY {
+            return Err(format!(
+                "INV-RC001 violated: tool_capacity ({tool_capacity}) must be >= {MIN_BUFFER_CAPACITY}"
+            ));
+        }
+        if telemetry_capacity < MIN_BUFFER_CAPACITY {
+            return Err(format!(
+                "INV-RC001 violated: telemetry_capacity ({telemetry_capacity}) must be >= {MIN_BUFFER_CAPACITY}"
+            ));
+        }
+
+        // Bounds check (CTR-1303)
+        if pty_capacity > MAX_BUFFER_CAPACITY {
+            return Err(format!(
+                "pty_capacity ({pty_capacity}) exceeds MAX_BUFFER_CAPACITY ({MAX_BUFFER_CAPACITY})"
+            ));
+        }
+        if tool_capacity > MAX_BUFFER_CAPACITY {
+            return Err(format!(
+                "tool_capacity ({tool_capacity}) exceeds MAX_BUFFER_CAPACITY ({MAX_BUFFER_CAPACITY})"
+            ));
+        }
+        if telemetry_capacity > MAX_BUFFER_CAPACITY {
+            return Err(format!(
+                "telemetry_capacity ({telemetry_capacity}) exceeds MAX_BUFFER_CAPACITY ({MAX_BUFFER_CAPACITY})"
+            ));
+        }
+
+        Ok(Self {
+            pty_capacity,
+            tool_capacity,
+            telemetry_capacity,
+        })
+    }
+
+    /// Creates a configuration from a risk tier.
+    ///
+    /// Per AD-EVID-001, buffer sizes scale with risk tier:
+    /// - Tier 0-1: Minimal buffers for read-only/local development
+    /// - Tier 2: Medium buffers for production-adjacent operations
+    /// - Tier 3+: Large buffers for critical operations
+    #[must_use]
+    pub const fn from_risk_tier(tier: RiskTier) -> Self {
+        match tier {
+            // INV-RC002: Tier 0 uses tier 1 values (minimal but non-zero)
+            RiskTier::Tier0 | RiskTier::Tier1 => Self {
+                pty_capacity: TIER_1_PTY_CAPACITY,
+                tool_capacity: TIER_1_TOOL_CAPACITY,
+                telemetry_capacity: TIER_1_TELEMETRY_CAPACITY,
+            },
+            RiskTier::Tier2 => Self {
+                pty_capacity: TIER_2_PTY_CAPACITY,
+                tool_capacity: TIER_2_TOOL_CAPACITY,
+                telemetry_capacity: TIER_2_TELEMETRY_CAPACITY,
+            },
+            // INV-RC003: Tier 3+ gets largest buffers
+            RiskTier::Tier3 | RiskTier::Tier4 => Self {
+                pty_capacity: TIER_3_PLUS_PTY_CAPACITY,
+                tool_capacity: TIER_3_PLUS_TOOL_CAPACITY,
+                telemetry_capacity: TIER_3_PLUS_TELEMETRY_CAPACITY,
+            },
+        }
+    }
+
+    /// Returns the PTY output buffer capacity (item count).
+    #[must_use]
+    pub const fn pty_capacity(&self) -> usize {
+        self.pty_capacity
+    }
+
+    /// Returns the tool event buffer capacity (item count).
+    #[must_use]
+    pub const fn tool_capacity(&self) -> usize {
+        self.tool_capacity
+    }
+
+    /// Returns the telemetry frame buffer capacity (item count).
+    #[must_use]
+    pub const fn telemetry_capacity(&self) -> usize {
+        self.telemetry_capacity
+    }
+
+    /// Returns estimated total memory usage in bytes.
+    ///
+    /// This is an approximation based on estimated item sizes. Actual
+    /// memory usage may vary based on actual item contents.
+    #[must_use]
+    pub const fn estimated_memory_bytes(&self) -> usize {
+        self.pty_capacity * ESTIMATED_PTY_CHUNK_SIZE
+            + self.tool_capacity * ESTIMATED_TOOL_EVENT_SIZE
+            + self.telemetry_capacity * ESTIMATED_TELEMETRY_FRAME_SIZE
+    }
+
+    /// Creates a builder for custom configuration.
+    #[must_use]
+    pub const fn builder() -> RecorderConfigBuilder {
+        RecorderConfigBuilder::new()
+    }
+}
+
+impl Default for RecorderConfig {
+    /// Default configuration uses Tier 1 capacities.
+    fn default() -> Self {
+        Self::from_risk_tier(RiskTier::Tier1)
+    }
+}
+
+// =============================================================================
+// RecorderConfigBuilder
+// =============================================================================
+
+/// Builder for `RecorderConfig`.
+///
+/// All capacities are clamped to valid ranges on build.
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_field_names)] // Capacity suffix is intentional for clarity
+pub struct RecorderConfigBuilder {
+    pty_capacity: usize,
+    tool_capacity: usize,
+    telemetry_capacity: usize,
+}
+
+impl RecorderConfigBuilder {
+    /// Creates a new builder with Tier 1 defaults.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            pty_capacity: TIER_1_PTY_CAPACITY,
+            tool_capacity: TIER_1_TOOL_CAPACITY,
+            telemetry_capacity: TIER_1_TELEMETRY_CAPACITY,
+        }
+    }
+
+    /// Sets the PTY buffer capacity.
+    #[must_use]
+    pub const fn pty_capacity(mut self, capacity: usize) -> Self {
+        self.pty_capacity = capacity;
+        self
+    }
+
+    /// Sets the tool buffer capacity.
+    #[must_use]
+    pub const fn tool_capacity(mut self, capacity: usize) -> Self {
+        self.tool_capacity = capacity;
+        self
+    }
+
+    /// Sets the telemetry buffer capacity.
+    #[must_use]
+    pub const fn telemetry_capacity(mut self, capacity: usize) -> Self {
+        self.telemetry_capacity = capacity;
+        self
+    }
+
+    /// Builds the configuration with validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any capacity violates invariants.
+    pub fn build(self) -> Result<RecorderConfig, String> {
+        RecorderConfig::try_new(
+            self.pty_capacity,
+            self.tool_capacity,
+            self.telemetry_capacity,
+        )
+    }
+
+    /// Builds the configuration, clamping values to valid ranges.
+    ///
+    /// This never fails - invalid values are clamped.
+    #[must_use]
+    pub fn build_clamped(self) -> RecorderConfig {
+        RecorderConfig {
+            pty_capacity: self
+                .pty_capacity
+                .clamp(MIN_BUFFER_CAPACITY, MAX_BUFFER_CAPACITY),
+            tool_capacity: self
+                .tool_capacity
+                .clamp(MIN_BUFFER_CAPACITY, MAX_BUFFER_CAPACITY),
+            telemetry_capacity: self
+                .telemetry_capacity
+                .clamp(MIN_BUFFER_CAPACITY, MAX_BUFFER_CAPACITY),
+        }
+    }
+}
+
+impl Default for RecorderConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // UT-00170-03: Tier configuration tests
+    // =========================================================================
+
+    #[test]
+    fn test_recorder_config_tier_1() {
+        let config = RecorderConfig::from_risk_tier(RiskTier::Tier1);
+
+        assert_eq!(config.pty_capacity(), TIER_1_PTY_CAPACITY);
+        assert_eq!(config.tool_capacity(), TIER_1_TOOL_CAPACITY);
+        assert_eq!(config.telemetry_capacity(), TIER_1_TELEMETRY_CAPACITY);
+    }
+
+    #[test]
+    fn test_recorder_config_tier_2() {
+        let config = RecorderConfig::from_risk_tier(RiskTier::Tier2);
+
+        assert_eq!(config.pty_capacity(), TIER_2_PTY_CAPACITY);
+        assert_eq!(config.tool_capacity(), TIER_2_TOOL_CAPACITY);
+        assert_eq!(config.telemetry_capacity(), TIER_2_TELEMETRY_CAPACITY);
+    }
+
+    #[test]
+    fn test_recorder_config_tier_3_plus() {
+        let config_t3 = RecorderConfig::from_risk_tier(RiskTier::Tier3);
+        let config_t4 = RecorderConfig::from_risk_tier(RiskTier::Tier4);
+
+        // Tier 3 and 4 should have same (largest) buffers
+        assert_eq!(config_t3.pty_capacity(), TIER_3_PLUS_PTY_CAPACITY);
+        assert_eq!(config_t3.tool_capacity(), TIER_3_PLUS_TOOL_CAPACITY);
+        assert_eq!(
+            config_t3.telemetry_capacity(),
+            TIER_3_PLUS_TELEMETRY_CAPACITY
+        );
+
+        assert_eq!(config_t4.pty_capacity(), config_t3.pty_capacity());
+        assert_eq!(config_t4.tool_capacity(), config_t3.tool_capacity());
+        assert_eq!(
+            config_t4.telemetry_capacity(),
+            config_t3.telemetry_capacity()
+        );
+    }
+
+    /// INV-RC002: Tier 0 uses tier 1 values.
+    #[test]
+    fn test_recorder_config_tier_0_uses_tier_1() {
+        let config_t0 = RecorderConfig::from_risk_tier(RiskTier::Tier0);
+        let config_t1 = RecorderConfig::from_risk_tier(RiskTier::Tier1);
+
+        assert_eq!(config_t0.pty_capacity(), config_t1.pty_capacity());
+        assert_eq!(config_t0.tool_capacity(), config_t1.tool_capacity());
+        assert_eq!(
+            config_t0.telemetry_capacity(),
+            config_t1.telemetry_capacity()
+        );
+    }
+
+    /// INV-RC003: Higher tiers never have smaller buffers.
+    #[test]
+    fn test_recorder_config_tier_monotonicity() {
+        let t1 = RecorderConfig::from_risk_tier(RiskTier::Tier1);
+        let t2 = RecorderConfig::from_risk_tier(RiskTier::Tier2);
+        let t3 = RecorderConfig::from_risk_tier(RiskTier::Tier3);
+
+        // Tier 2 >= Tier 1
+        assert!(t2.pty_capacity() >= t1.pty_capacity());
+        assert!(t2.tool_capacity() >= t1.tool_capacity());
+        assert!(t2.telemetry_capacity() >= t1.telemetry_capacity());
+
+        // Tier 3 >= Tier 2
+        assert!(t3.pty_capacity() >= t2.pty_capacity());
+        assert!(t3.tool_capacity() >= t2.tool_capacity());
+        assert!(t3.telemetry_capacity() >= t2.telemetry_capacity());
+    }
+
+    #[test]
+    fn test_recorder_config_try_new_valid() {
+        let result = RecorderConfig::try_new(100, 200, 300);
+        assert!(result.is_ok());
+
+        let config = result.unwrap();
+        assert_eq!(config.pty_capacity(), 100);
+        assert_eq!(config.tool_capacity(), 200);
+        assert_eq!(config.telemetry_capacity(), 300);
+    }
+
+    /// INV-RC001: Zero capacity is rejected.
+    #[test]
+    fn test_recorder_config_try_new_zero_rejected() {
+        assert!(RecorderConfig::try_new(0, 100, 100).is_err());
+        assert!(RecorderConfig::try_new(100, 0, 100).is_err());
+        assert!(RecorderConfig::try_new(100, 100, 0).is_err());
+    }
+
+    #[test]
+    fn test_recorder_config_try_new_exceeds_max() {
+        let too_large = MAX_BUFFER_CAPACITY + 1;
+
+        assert!(RecorderConfig::try_new(too_large, 100, 100).is_err());
+        assert!(RecorderConfig::try_new(100, too_large, 100).is_err());
+        assert!(RecorderConfig::try_new(100, 100, too_large).is_err());
+    }
+
+    #[test]
+    fn test_recorder_config_builder() {
+        let config = RecorderConfig::builder()
+            .pty_capacity(500)
+            .tool_capacity(600)
+            .telemetry_capacity(700)
+            .build()
+            .unwrap();
+
+        assert_eq!(config.pty_capacity(), 500);
+        assert_eq!(config.tool_capacity(), 600);
+        assert_eq!(config.telemetry_capacity(), 700);
+    }
+
+    #[test]
+    fn test_recorder_config_builder_clamped() {
+        // Zero values should be clamped to MIN_BUFFER_CAPACITY
+        let config = RecorderConfig::builder()
+            .pty_capacity(0)
+            .tool_capacity(0)
+            .telemetry_capacity(0)
+            .build_clamped();
+
+        assert_eq!(config.pty_capacity(), MIN_BUFFER_CAPACITY);
+        assert_eq!(config.tool_capacity(), MIN_BUFFER_CAPACITY);
+        assert_eq!(config.telemetry_capacity(), MIN_BUFFER_CAPACITY);
+
+        // Large values should be clamped to MAX_BUFFER_CAPACITY
+        let config = RecorderConfig::builder()
+            .pty_capacity(MAX_BUFFER_CAPACITY * 2)
+            .tool_capacity(MAX_BUFFER_CAPACITY * 2)
+            .telemetry_capacity(MAX_BUFFER_CAPACITY * 2)
+            .build_clamped();
+
+        assert_eq!(config.pty_capacity(), MAX_BUFFER_CAPACITY);
+        assert_eq!(config.tool_capacity(), MAX_BUFFER_CAPACITY);
+        assert_eq!(config.telemetry_capacity(), MAX_BUFFER_CAPACITY);
+    }
+
+    #[test]
+    fn test_recorder_config_default() {
+        let config = RecorderConfig::default();
+        let tier1 = RecorderConfig::from_risk_tier(RiskTier::Tier1);
+
+        assert_eq!(config, tier1);
+    }
+
+    #[test]
+    fn test_recorder_config_estimated_memory() {
+        let config = RecorderConfig::from_risk_tier(RiskTier::Tier1);
+        let estimated = config.estimated_memory_bytes();
+
+        // Tier 1: 256*4KB + 256*2KB + 1024*256B = 1MB + 512KB + 256KB = ~1.75MB
+        let expected = TIER_1_PTY_CAPACITY * ESTIMATED_PTY_CHUNK_SIZE
+            + TIER_1_TOOL_CAPACITY * ESTIMATED_TOOL_EVENT_SIZE
+            + TIER_1_TELEMETRY_CAPACITY * ESTIMATED_TELEMETRY_FRAME_SIZE;
+
+        assert_eq!(estimated, expected);
+    }
+
+    #[test]
+    fn test_recorder_config_serialization() {
+        let config = RecorderConfig::try_new(100, 200, 300).unwrap();
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: RecorderConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(config, deserialized);
+    }
+
+    /// SECURITY: Verify unknown fields are rejected.
+    #[test]
+    fn test_recorder_config_rejects_unknown_fields() {
+        let json = r#"{
+            "pty_capacity": 100,
+            "tool_capacity": 200,
+            "telemetry_capacity": 300,
+            "malicious": "attack"
+        }"#;
+
+        let result: Result<RecorderConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "should reject unknown fields");
+    }
+}

--- a/crates/apm2-daemon/src/evidence/mod.rs
+++ b/crates/apm2-daemon/src/evidence/mod.rs
@@ -15,7 +15,10 @@
 //!     |-- signer.rs          - ReceiptSigner using Ed25519 (TCK-00167)
 //!     |-- verifier.rs        - Receipt verification predicate (TCK-00167)
 //!     |-- keychain.rs        - OS keychain integration for keys (TCK-00167)
-//!     `-- (future: recorder.rs, ttl.rs, compaction.rs)
+//!     |-- config.rs          - RecorderConfig per risk tier (TCK-00170)
+//!     |-- trigger.rs         - Persistence trigger conditions (TCK-00170)
+//!     |-- recorder.rs        - FlightRecorder implementation (TCK-00170)
+//!     `-- (future: ttl.rs, compaction.rs)
 //! ```
 //!
 //! # Security Model
@@ -47,9 +50,22 @@ pub mod keychain;
 pub mod signer;
 pub mod verifier;
 
+// TCK-00170: Flight recorder with ring buffers
+pub mod config;
+pub mod recorder;
+pub mod trigger;
+
 // Re-export core receipt types
 // Re-export binding types
 pub use binding::{EvidenceBinding, ToolEvidenceCollector};
+// Re-export flight recorder types (TCK-00170)
+pub use config::{
+    ESTIMATED_PTY_CHUNK_SIZE, ESTIMATED_TELEMETRY_FRAME_SIZE, ESTIMATED_TOOL_EVENT_SIZE,
+    MAX_BUFFER_CAPACITY, MIN_BUFFER_CAPACITY, RecorderConfig, RecorderConfigBuilder,
+    TIER_1_PTY_CAPACITY, TIER_1_TELEMETRY_CAPACITY, TIER_1_TOOL_CAPACITY, TIER_2_PTY_CAPACITY,
+    TIER_2_TELEMETRY_CAPACITY, TIER_2_TOOL_CAPACITY, TIER_3_PLUS_PTY_CAPACITY,
+    TIER_3_PLUS_TELEMETRY_CAPACITY, TIER_3_PLUS_TOOL_CAPACITY,
+};
 // Re-export keychain types (TCK-00167)
 pub use keychain::{
     InMemoryKeyStore, KEYCHAIN_SERVICE_NAME, KeyInfo, KeychainError, MAX_STORED_KEYS, OsKeychain,
@@ -63,8 +79,13 @@ pub use receipt::{
 };
 // Re-export builder
 pub use receipt_builder::{ReceiptBuilder, ReceiptSigning};
+pub use recorder::{EvidenceBundle, FlightRecorder, PersistResult, ToolEvent};
 // Re-export signer types (TCK-00167)
 pub use signer::{INITIAL_KEY_VERSION, KeyId, MAX_KEY_ID_LEN, ReceiptSigner, SignerError};
+pub use trigger::{
+    MAX_ACTOR_LEN, MAX_GATE_ID_LEN, MAX_REASON_LEN, MAX_RESOURCE_LEN,
+    MAX_RULE_ID_LEN as MAX_TRIGGER_RULE_ID_LEN, MAX_VIOLATION_LEN, PersistTrigger, TriggerCategory,
+};
 // Re-export verifier types (TCK-00167)
 pub use verifier::{
     VerificationError, VerificationResult, verify_receipt, verify_receipt_integrity,
@@ -72,6 +93,5 @@ pub use verifier::{
 };
 
 // Placeholder exports for future evidence types.
-// TODO(TCK-00170): Implement FlightRecorder, RingBuffer, and retention types.
 // TODO(TCK-00171): Implement TTL and pinning types.
 // TODO(TCK-00172): Implement compaction types.

--- a/crates/apm2-daemon/src/evidence/recorder.rs
+++ b/crates/apm2-daemon/src/evidence/recorder.rs
@@ -1,0 +1,887 @@
+//! Flight recorder implementation for episode evidence.
+//!
+//! This module implements the `FlightRecorder` per AD-EVID-001, providing
+//! per-episode ring buffers for PTY output, tool I/O, and telemetry frames.
+//! Evidence is persisted to the content-addressed store on abnormal
+//! termination.
+//!
+//! # Architecture
+//!
+//! ```text
+//! FlightRecorder
+//!     |
+//!     +-- pty_buffer: RingBuffer<PtyOutput>
+//!     +-- tool_buffer: RingBuffer<ToolEvent>
+//!     +-- telemetry_buffer: RingBuffer<TelemetryFrame>
+//!     +-- config: RecorderConfig
+//!     |
+//!     +-- push_pty(output) - Add PTY output
+//!     +-- push_tool(event) - Add tool event
+//!     +-- push_telemetry(frame) - Add telemetry frame
+//!     +-- persist(cas, trigger) -> Vec<Hash> - Flush to CAS
+//!     +-- clear() - Empty all buffers
+//! ```
+//!
+//! # Lifecycle
+//!
+//! 1. Create recorder on episode creation with `new(risk_tier)`
+//! 2. Push data during execution via `push_*` methods
+//! 3. On normal termination, call `clear()` (evidence discarded)
+//! 4. On abnormal termination, call `persist(cas, trigger)` (evidence retained)
+//!
+//! # Security Model
+//!
+//! - Buffers are bounded per risk tier to prevent memory exhaustion
+//! - Evidence is content-addressed for integrity verification
+//! - Persistence returns hashes for binding into receipts
+//! - All operations are fail-closed (errors preserve evidence)
+//!
+//! # Invariants
+//!
+//! - [INV-FR001] Buffers respect configured capacity limits
+//! - [INV-FR002] Oldest data is evicted when buffers are full
+//! - [INV-FR003] Persist returns hashes for all non-empty buffers
+//! - [INV-FR004] Clear empties all buffers completely
+//!
+//! # Contract References
+//!
+//! - AD-EVID-001: Flight recorder and ring buffers
+//! - CTR-1303: Bounded collections
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, instrument};
+
+use super::config::RecorderConfig;
+use super::trigger::PersistTrigger;
+use crate::episode::executor::ContentAddressedStore;
+use crate::episode::output::{PtyOutput, PtyOutputRecord};
+use crate::episode::ring_buffer::RingBuffer;
+use crate::episode::{Hash, RiskTier};
+use crate::telemetry::TelemetryFrame;
+
+// =============================================================================
+// ToolEvent
+// =============================================================================
+
+/// A tool event recorded for flight recorder evidence.
+///
+/// This captures tool requests and responses for debugging and audit.
+/// The structure is designed to be serializable for CAS storage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ToolEvent {
+    /// Unique request ID.
+    pub request_id: String,
+
+    /// Tool class (read, write, execute, etc.).
+    pub tool_class: String,
+
+    /// Timestamp when the tool was invoked (nanoseconds).
+    pub invoked_at_ns: u64,
+
+    /// Timestamp when the tool completed (nanoseconds).
+    pub completed_at_ns: Option<u64>,
+
+    /// Whether the tool execution succeeded.
+    pub success: bool,
+
+    /// Error message if the tool failed.
+    pub error_message: Option<String>,
+
+    /// Hash of the arguments (stored separately in CAS).
+    pub args_hash: Option<Hash>,
+
+    /// Hash of the result (stored separately in CAS).
+    pub result_hash: Option<Hash>,
+
+    /// Budget delta consumed by this tool.
+    pub budget_tokens: u64,
+
+    /// I/O bytes consumed by this tool.
+    pub budget_bytes_io: u64,
+}
+
+impl ToolEvent {
+    /// Creates a new tool event for a started invocation.
+    #[must_use]
+    pub fn started(
+        request_id: impl Into<String>,
+        tool_class: impl Into<String>,
+        invoked_at_ns: u64,
+        args_hash: Option<Hash>,
+    ) -> Self {
+        Self {
+            request_id: request_id.into(),
+            tool_class: tool_class.into(),
+            invoked_at_ns,
+            completed_at_ns: None,
+            success: false,
+            error_message: None,
+            args_hash,
+            result_hash: None,
+            budget_tokens: 0,
+            budget_bytes_io: 0,
+        }
+    }
+
+    /// Marks the event as completed successfully.
+    #[must_use]
+    pub const fn completed(
+        mut self,
+        completed_at_ns: u64,
+        result_hash: Option<Hash>,
+        budget_tokens: u64,
+        budget_bytes_io: u64,
+    ) -> Self {
+        self.completed_at_ns = Some(completed_at_ns);
+        self.success = true;
+        self.result_hash = result_hash;
+        self.budget_tokens = budget_tokens;
+        self.budget_bytes_io = budget_bytes_io;
+        self
+    }
+
+    /// Marks the event as failed.
+    #[must_use]
+    pub fn failed(
+        mut self,
+        completed_at_ns: u64,
+        error_message: impl Into<String>,
+        budget_tokens: u64,
+        budget_bytes_io: u64,
+    ) -> Self {
+        self.completed_at_ns = Some(completed_at_ns);
+        self.success = false;
+        self.error_message = Some(error_message.into());
+        self.budget_tokens = budget_tokens;
+        self.budget_bytes_io = budget_bytes_io;
+        self
+    }
+
+    /// Returns the duration in nanoseconds, if completed.
+    #[must_use]
+    pub fn duration_ns(&self) -> Option<u64> {
+        self.completed_at_ns
+            .map(|c| c.saturating_sub(self.invoked_at_ns))
+    }
+}
+
+// =============================================================================
+// EvidenceBundle
+// =============================================================================
+
+/// A bundle of serialized evidence ready for CAS storage.
+///
+/// This intermediate representation holds the serialized data before
+/// it is stored in the CAS.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceBundle {
+    /// PTY output records.
+    pub pty_records: Vec<PtyOutputRecord>,
+
+    /// Tool events.
+    pub tool_events: Vec<ToolEvent>,
+
+    /// Telemetry frames.
+    pub telemetry_frames: Vec<TelemetryFrame>,
+
+    /// Trigger that caused persistence.
+    pub trigger: PersistTrigger,
+
+    /// Timestamp when persistence was triggered (nanoseconds).
+    pub persisted_at_ns: u64,
+}
+
+impl EvidenceBundle {
+    /// Returns `true` if the bundle contains any evidence.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.pty_records.is_empty()
+            && self.tool_events.is_empty()
+            && self.telemetry_frames.is_empty()
+    }
+
+    /// Returns the total number of items in the bundle.
+    #[must_use]
+    pub fn total_items(&self) -> usize {
+        self.pty_records.len() + self.tool_events.len() + self.telemetry_frames.len()
+    }
+}
+
+// =============================================================================
+// PersistResult
+// =============================================================================
+
+/// Result of persisting flight recorder evidence.
+#[derive(Debug, Clone)]
+pub struct PersistResult {
+    /// Hash of the PTY evidence, if any was persisted.
+    pub pty_hash: Option<Hash>,
+
+    /// Hash of the tool evidence, if any was persisted.
+    pub tool_hash: Option<Hash>,
+
+    /// Hash of the telemetry evidence, if any was persisted.
+    pub telemetry_hash: Option<Hash>,
+
+    /// Hash of the complete evidence bundle.
+    pub bundle_hash: Hash,
+
+    /// Number of PTY records persisted.
+    pub pty_count: usize,
+
+    /// Number of tool events persisted.
+    pub tool_count: usize,
+
+    /// Number of telemetry frames persisted.
+    pub telemetry_count: usize,
+}
+
+impl PersistResult {
+    /// Returns all non-None hashes as a vector.
+    #[must_use]
+    pub fn all_hashes(&self) -> Vec<Hash> {
+        let mut hashes = vec![self.bundle_hash];
+
+        if let Some(h) = self.pty_hash {
+            hashes.push(h);
+        }
+        if let Some(h) = self.tool_hash {
+            hashes.push(h);
+        }
+        if let Some(h) = self.telemetry_hash {
+            hashes.push(h);
+        }
+
+        hashes
+    }
+
+    /// Returns the total number of items persisted.
+    #[must_use]
+    pub const fn total_items(&self) -> usize {
+        self.pty_count + self.tool_count + self.telemetry_count
+    }
+}
+
+// =============================================================================
+// FlightRecorder
+// =============================================================================
+
+/// Flight recorder for per-episode evidence collection.
+///
+/// The flight recorder maintains ring buffers for PTY output, tool I/O,
+/// and telemetry frames. On abnormal termination, the buffers are
+/// persisted to the content-addressed store for debugging and audit.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use apm2_daemon::evidence::recorder::FlightRecorder;
+/// use apm2_daemon::episode::RiskTier;
+///
+/// // Create recorder for tier 2 episode
+/// let mut recorder = FlightRecorder::new(RiskTier::Tier2);
+///
+/// // Push data during execution
+/// recorder.push_pty(pty_output);
+/// recorder.push_tool(tool_event);
+/// recorder.push_telemetry(frame);
+///
+/// // On abnormal termination, persist evidence
+/// let trigger = PersistTrigger::from_exit_code(1);
+/// let result = recorder.persist(&cas, trigger, timestamp_ns)?;
+///
+/// // On normal termination, discard evidence
+/// recorder.clear();
+/// ```
+pub struct FlightRecorder {
+    /// PTY output buffer.
+    pty_buffer: RingBuffer<PtyOutput>,
+
+    /// Tool event buffer.
+    tool_buffer: RingBuffer<ToolEvent>,
+
+    /// Telemetry frame buffer.
+    telemetry_buffer: RingBuffer<TelemetryFrame>,
+
+    /// Configuration for this recorder.
+    config: RecorderConfig,
+}
+
+impl FlightRecorder {
+    /// Creates a new flight recorder for the given risk tier.
+    ///
+    /// Buffer sizes are determined by the risk tier per AD-EVID-001.
+    #[must_use]
+    pub fn new(risk_tier: RiskTier) -> Self {
+        Self::with_config(RecorderConfig::from_risk_tier(risk_tier))
+    }
+
+    /// Creates a new flight recorder with custom configuration.
+    #[must_use]
+    pub fn with_config(config: RecorderConfig) -> Self {
+        Self {
+            pty_buffer: RingBuffer::new(config.pty_capacity()),
+            tool_buffer: RingBuffer::new(config.tool_capacity()),
+            telemetry_buffer: RingBuffer::new(config.telemetry_capacity()),
+            config,
+        }
+    }
+
+    /// Returns the configuration for this recorder.
+    #[must_use]
+    pub const fn config(&self) -> &RecorderConfig {
+        &self.config
+    }
+
+    // =========================================================================
+    // Push Methods
+    // =========================================================================
+
+    /// Pushes PTY output to the buffer.
+    ///
+    /// If the buffer is full, the oldest output is evicted.
+    pub fn push_pty(&mut self, output: PtyOutput) {
+        self.pty_buffer.push(output);
+    }
+
+    /// Pushes a tool event to the buffer.
+    ///
+    /// If the buffer is full, the oldest event is evicted.
+    pub fn push_tool(&mut self, event: ToolEvent) {
+        self.tool_buffer.push(event);
+    }
+
+    /// Pushes a telemetry frame to the buffer.
+    ///
+    /// If the buffer is full, the oldest frame is evicted.
+    pub fn push_telemetry(&mut self, frame: TelemetryFrame) {
+        self.telemetry_buffer.push(frame);
+    }
+
+    // =========================================================================
+    // Query Methods
+    // =========================================================================
+
+    /// Returns the number of PTY outputs in the buffer.
+    #[must_use]
+    pub fn pty_len(&self) -> usize {
+        self.pty_buffer.len()
+    }
+
+    /// Returns the number of tool events in the buffer.
+    #[must_use]
+    pub fn tool_len(&self) -> usize {
+        self.tool_buffer.len()
+    }
+
+    /// Returns the number of telemetry frames in the buffer.
+    #[must_use]
+    pub fn telemetry_len(&self) -> usize {
+        self.telemetry_buffer.len()
+    }
+
+    /// Returns the total number of items across all buffers.
+    #[must_use]
+    pub fn total_len(&self) -> usize {
+        self.pty_len() + self.tool_len() + self.telemetry_len()
+    }
+
+    /// Returns `true` if all buffers are empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.pty_buffer.is_empty()
+            && self.tool_buffer.is_empty()
+            && self.telemetry_buffer.is_empty()
+    }
+
+    /// Returns the estimated memory usage in bytes.
+    #[must_use]
+    pub fn estimated_memory_bytes(&self) -> usize {
+        // This is a rough estimate based on current buffer lengths
+        // and estimated item sizes
+        use super::config::{
+            ESTIMATED_PTY_CHUNK_SIZE, ESTIMATED_TELEMETRY_FRAME_SIZE, ESTIMATED_TOOL_EVENT_SIZE,
+        };
+
+        self.pty_len() * ESTIMATED_PTY_CHUNK_SIZE
+            + self.tool_len() * ESTIMATED_TOOL_EVENT_SIZE
+            + self.telemetry_len() * ESTIMATED_TELEMETRY_FRAME_SIZE
+    }
+
+    // =========================================================================
+    // Persistence
+    // =========================================================================
+
+    /// Persists all buffer contents to the content-addressed store.
+    ///
+    /// This method:
+    /// 1. Drains all buffers
+    /// 2. Serializes evidence to JSON
+    /// 3. Stores each category separately in CAS
+    /// 4. Stores a combined bundle with the trigger
+    /// 5. Returns hashes for all stored evidence
+    ///
+    /// # Arguments
+    ///
+    /// * `cas` - Content-addressed store for evidence storage
+    /// * `trigger` - The trigger that caused persistence
+    /// * `timestamp_ns` - Current timestamp in nanoseconds
+    ///
+    /// # Returns
+    ///
+    /// A `PersistResult` containing hashes of all stored evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string if serialization fails.
+    #[instrument(skip(self, cas), fields(trigger_type = %trigger.trigger_type()))]
+    pub fn persist(
+        &mut self,
+        cas: &Arc<dyn ContentAddressedStore>,
+        trigger: PersistTrigger,
+        timestamp_ns: u64,
+    ) -> Result<PersistResult, String> {
+        debug!(
+            pty_count = self.pty_len(),
+            tool_count = self.tool_len(),
+            telemetry_count = self.telemetry_len(),
+            "persisting flight recorder evidence"
+        );
+
+        // Drain all buffers and convert to serializable records
+        let pty_records: Vec<PtyOutputRecord> =
+            self.pty_buffer.drain().map(PtyOutputRecord::from).collect();
+        let tool_events: Vec<ToolEvent> = self.tool_buffer.drain().collect();
+        let telemetry_frames: Vec<TelemetryFrame> = self.telemetry_buffer.drain().collect();
+
+        let pty_count = pty_records.len();
+        let tool_count = tool_events.len();
+        let telemetry_count = telemetry_frames.len();
+
+        // Store each category separately (for selective retrieval)
+        let pty_hash = if pty_records.is_empty() {
+            None
+        } else {
+            let bytes = serde_json::to_vec(&pty_records)
+                .map_err(|e| format!("failed to serialize PTY evidence: {e}"))?;
+            Some(cas.store(&bytes))
+        };
+
+        let tool_hash = if tool_events.is_empty() {
+            None
+        } else {
+            let bytes = serde_json::to_vec(&tool_events)
+                .map_err(|e| format!("failed to serialize tool evidence: {e}"))?;
+            Some(cas.store(&bytes))
+        };
+
+        let telemetry_hash = if telemetry_frames.is_empty() {
+            None
+        } else {
+            let bytes = serde_json::to_vec(&telemetry_frames)
+                .map_err(|e| format!("failed to serialize telemetry evidence: {e}"))?;
+            Some(cas.store(&bytes))
+        };
+
+        // Create and store the complete bundle
+        let bundle = EvidenceBundle {
+            pty_records,
+            tool_events,
+            telemetry_frames,
+            trigger,
+            persisted_at_ns: timestamp_ns,
+        };
+
+        let bundle_bytes = serde_json::to_vec(&bundle)
+            .map_err(|e| format!("failed to serialize evidence bundle: {e}"))?;
+        let bundle_hash = cas.store(&bundle_bytes);
+
+        debug!(
+            bundle_hash = %hex::encode(&bundle_hash[..8]),
+            pty_count,
+            tool_count,
+            telemetry_count,
+            "evidence persisted successfully"
+        );
+
+        Ok(PersistResult {
+            pty_hash,
+            tool_hash,
+            telemetry_hash,
+            bundle_hash,
+            pty_count,
+            tool_count,
+            telemetry_count,
+        })
+    }
+
+    // =========================================================================
+    // Clear
+    // =========================================================================
+
+    /// Clears all buffers, discarding all evidence.
+    ///
+    /// This should be called on normal episode termination when
+    /// evidence retention is not needed.
+    pub fn clear(&mut self) {
+        self.pty_buffer.clear();
+        self.tool_buffer.clear();
+        self.telemetry_buffer.clear();
+    }
+}
+
+impl std::fmt::Debug for FlightRecorder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FlightRecorder")
+            .field("config", &self.config)
+            .field("pty_len", &self.pty_len())
+            .field("tool_len", &self.tool_len())
+            .field("telemetry_len", &self.telemetry_len())
+            .finish_non_exhaustive()
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::episode::EpisodeId;
+    use crate::episode::broker::StubContentAddressedStore;
+    use crate::episode::output::StreamKind;
+    use crate::telemetry::O11yFlags;
+    use crate::telemetry::stats::MetricSource;
+
+    fn test_pty_output(seq: u64) -> PtyOutput {
+        PtyOutput::new(
+            Bytes::from(format!("output chunk {seq}")),
+            seq,
+            1_000_000 * seq,
+            StreamKind::Combined,
+        )
+    }
+
+    fn test_tool_event(request_id: &str) -> ToolEvent {
+        ToolEvent::started(request_id, "read", 1_000_000_000, None)
+    }
+
+    fn test_telemetry_frame(seq: u64) -> TelemetryFrame {
+        let episode_id = EpisodeId::new("test-episode").unwrap();
+        TelemetryFrame::builder(episode_id, seq)
+            .ts_mono(seq * 1_000_000)
+            .cpu_ns(seq * 100_000)
+            .source(MetricSource::Cgroup)
+            .o11y_flags(O11yFlags::new())
+            .build()
+    }
+
+    // =========================================================================
+    // UT-00170-01: Ring buffer bounds
+    // =========================================================================
+
+    #[test]
+    fn test_recorder_bounds_pty() {
+        // Create a recorder with small capacity for testing
+        let config = RecorderConfig::try_new(3, 3, 3).unwrap();
+        let mut recorder = FlightRecorder::with_config(config);
+
+        // Push more items than capacity
+        for i in 0..10 {
+            recorder.push_pty(test_pty_output(i));
+        }
+
+        // Should only contain last 3 items
+        assert_eq!(recorder.pty_len(), 3);
+    }
+
+    #[test]
+    fn test_recorder_bounds_tool() {
+        let config = RecorderConfig::try_new(3, 3, 3).unwrap();
+        let mut recorder = FlightRecorder::with_config(config);
+
+        for i in 0..10 {
+            recorder.push_tool(test_tool_event(&format!("req-{i}")));
+        }
+
+        assert_eq!(recorder.tool_len(), 3);
+    }
+
+    #[test]
+    fn test_recorder_bounds_telemetry() {
+        let config = RecorderConfig::try_new(3, 3, 3).unwrap();
+        let mut recorder = FlightRecorder::with_config(config);
+
+        for i in 0..10 {
+            recorder.push_telemetry(test_telemetry_frame(i));
+        }
+
+        assert_eq!(recorder.telemetry_len(), 3);
+    }
+
+    // =========================================================================
+    // UT-00170-02: Persistence to CAS
+    // =========================================================================
+
+    #[test]
+    fn test_recorder_persist_stores_evidence() {
+        let mut recorder = FlightRecorder::new(RiskTier::Tier1);
+        let cas = Arc::new(StubContentAddressedStore::new());
+
+        // Add some evidence
+        recorder.push_pty(test_pty_output(0));
+        recorder.push_pty(test_pty_output(1));
+        recorder.push_tool(test_tool_event("req-1"));
+        recorder.push_telemetry(test_telemetry_frame(0));
+
+        // Persist
+        let trigger = PersistTrigger::from_exit_code(1);
+        let result = recorder
+            .persist(
+                &(cas as Arc<dyn ContentAddressedStore>),
+                trigger,
+                1_000_000_000,
+            )
+            .unwrap();
+
+        // Verify results
+        assert!(result.pty_hash.is_some());
+        assert!(result.tool_hash.is_some());
+        assert!(result.telemetry_hash.is_some());
+        assert_eq!(result.pty_count, 2);
+        assert_eq!(result.tool_count, 1);
+        assert_eq!(result.telemetry_count, 1);
+        assert_eq!(result.total_items(), 4);
+
+        // Buffers should be empty after persist
+        assert!(recorder.is_empty());
+    }
+
+    #[test]
+    fn test_recorder_persist_empty_buffers() {
+        let mut recorder = FlightRecorder::new(RiskTier::Tier1);
+        let cas = Arc::new(StubContentAddressedStore::new());
+
+        let trigger = PersistTrigger::from_exit_code(0);
+        let result = recorder
+            .persist(
+                &(cas as Arc<dyn ContentAddressedStore>),
+                trigger,
+                1_000_000_000,
+            )
+            .unwrap();
+
+        // Should still create bundle hash but no individual hashes
+        assert!(result.pty_hash.is_none());
+        assert!(result.tool_hash.is_none());
+        assert!(result.telemetry_hash.is_none());
+        assert_eq!(result.total_items(), 0);
+
+        // Bundle hash should always exist
+        assert_ne!(result.bundle_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn test_recorder_persist_returns_all_hashes() {
+        let mut recorder = FlightRecorder::new(RiskTier::Tier1);
+        let cas = Arc::new(StubContentAddressedStore::new());
+
+        recorder.push_pty(test_pty_output(0));
+        recorder.push_tool(test_tool_event("req-1"));
+        recorder.push_telemetry(test_telemetry_frame(0));
+
+        let trigger = PersistTrigger::from_exit_code(1);
+        let result = recorder
+            .persist(
+                &(cas as Arc<dyn ContentAddressedStore>),
+                trigger,
+                1_000_000_000,
+            )
+            .unwrap();
+
+        let all_hashes = result.all_hashes();
+        assert_eq!(all_hashes.len(), 4); // bundle + pty + tool + telemetry
+    }
+
+    // =========================================================================
+    // UT-00170-03: Tier configuration
+    // =========================================================================
+
+    #[test]
+    fn test_recorder_tier_1_capacities() {
+        let recorder = FlightRecorder::new(RiskTier::Tier1);
+        let config = recorder.config();
+
+        assert_eq!(
+            config.pty_capacity(),
+            super::super::config::TIER_1_PTY_CAPACITY
+        );
+        assert_eq!(
+            config.tool_capacity(),
+            super::super::config::TIER_1_TOOL_CAPACITY
+        );
+        assert_eq!(
+            config.telemetry_capacity(),
+            super::super::config::TIER_1_TELEMETRY_CAPACITY
+        );
+    }
+
+    #[test]
+    fn test_recorder_tier_2_capacities() {
+        let recorder = FlightRecorder::new(RiskTier::Tier2);
+        let config = recorder.config();
+
+        assert_eq!(
+            config.pty_capacity(),
+            super::super::config::TIER_2_PTY_CAPACITY
+        );
+        assert_eq!(
+            config.tool_capacity(),
+            super::super::config::TIER_2_TOOL_CAPACITY
+        );
+        assert_eq!(
+            config.telemetry_capacity(),
+            super::super::config::TIER_2_TELEMETRY_CAPACITY
+        );
+    }
+
+    #[test]
+    fn test_recorder_tier_3_capacities() {
+        let recorder = FlightRecorder::new(RiskTier::Tier3);
+        let config = recorder.config();
+
+        assert_eq!(
+            config.pty_capacity(),
+            super::super::config::TIER_3_PLUS_PTY_CAPACITY
+        );
+        assert_eq!(
+            config.tool_capacity(),
+            super::super::config::TIER_3_PLUS_TOOL_CAPACITY
+        );
+        assert_eq!(
+            config.telemetry_capacity(),
+            super::super::config::TIER_3_PLUS_TELEMETRY_CAPACITY
+        );
+    }
+
+    // =========================================================================
+    // Additional tests
+    // =========================================================================
+
+    #[test]
+    fn test_recorder_clear() {
+        let mut recorder = FlightRecorder::new(RiskTier::Tier1);
+
+        recorder.push_pty(test_pty_output(0));
+        recorder.push_tool(test_tool_event("req-1"));
+        recorder.push_telemetry(test_telemetry_frame(0));
+
+        assert!(!recorder.is_empty());
+        assert_eq!(recorder.total_len(), 3);
+
+        recorder.clear();
+
+        assert!(recorder.is_empty());
+        assert_eq!(recorder.total_len(), 0);
+    }
+
+    #[test]
+    fn test_recorder_estimated_memory() {
+        let mut recorder = FlightRecorder::new(RiskTier::Tier1);
+
+        assert_eq!(recorder.estimated_memory_bytes(), 0);
+
+        recorder.push_pty(test_pty_output(0));
+        recorder.push_tool(test_tool_event("req-1"));
+        recorder.push_telemetry(test_telemetry_frame(0));
+
+        let estimated = recorder.estimated_memory_bytes();
+        assert!(estimated > 0);
+    }
+
+    #[test]
+    fn test_tool_event_lifecycle() {
+        let event = ToolEvent::started("req-1", "read", 1_000_000_000, None);
+        assert!(!event.success);
+        assert!(event.completed_at_ns.is_none());
+        assert!(event.duration_ns().is_none());
+
+        let completed = event.completed(2_000_000_000, None, 100, 1024);
+        assert!(completed.success);
+        assert_eq!(completed.completed_at_ns, Some(2_000_000_000));
+        assert_eq!(completed.duration_ns(), Some(1_000_000_000));
+        assert_eq!(completed.budget_tokens, 100);
+        assert_eq!(completed.budget_bytes_io, 1024);
+    }
+
+    #[test]
+    fn test_tool_event_failure() {
+        let event = ToolEvent::started("req-2", "write", 1_000_000_000, None);
+        let failed = event.failed(1_500_000_000, "permission denied", 50, 0);
+
+        assert!(!failed.success);
+        assert_eq!(failed.error_message, Some("permission denied".to_string()));
+        assert_eq!(failed.duration_ns(), Some(500_000_000));
+    }
+
+    #[test]
+    fn test_evidence_bundle() {
+        let bundle = EvidenceBundle {
+            pty_records: vec![],
+            tool_events: vec![],
+            telemetry_frames: vec![],
+            trigger: PersistTrigger::from_exit_code(0),
+            persisted_at_ns: 1_000_000_000,
+        };
+
+        assert!(bundle.is_empty());
+        assert_eq!(bundle.total_items(), 0);
+    }
+
+    #[test]
+    fn test_tool_event_serialization() {
+        let event = ToolEvent::started("req-1", "read", 1_000_000_000, None);
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: ToolEvent = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(event, deserialized);
+    }
+
+    /// SECURITY: Verify unknown fields are rejected.
+    #[test]
+    fn test_tool_event_rejects_unknown_fields() {
+        let json = r#"{
+            "request_id": "req-1",
+            "tool_class": "read",
+            "invoked_at_ns": 1000000000,
+            "completed_at_ns": null,
+            "success": false,
+            "error_message": null,
+            "args_hash": null,
+            "result_hash": null,
+            "budget_tokens": 0,
+            "budget_bytes_io": 0,
+            "malicious": "attack"
+        }"#;
+
+        let result: Result<ToolEvent, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "should reject unknown fields");
+    }
+
+    #[test]
+    fn test_recorder_debug() {
+        let recorder = FlightRecorder::new(RiskTier::Tier1);
+        let debug_str = format!("{recorder:?}");
+
+        assert!(debug_str.contains("FlightRecorder"));
+        assert!(debug_str.contains("config"));
+        assert!(debug_str.contains("pty_len"));
+    }
+}

--- a/crates/apm2-daemon/src/evidence/trigger.rs
+++ b/crates/apm2-daemon/src/evidence/trigger.rs
@@ -1,0 +1,677 @@
+//! Trigger conditions for flight recorder persistence.
+//!
+//! This module defines `PersistTrigger` per AD-EVID-001, specifying the
+//! conditions under which the flight recorder should persist its buffers
+//! to the content-addressed store.
+//!
+//! # Architecture
+//!
+//! ```text
+//! PersistTrigger (enum)
+//!     |
+//!     +-- GateFailure { gate_id, reason }
+//!     +-- PolicyViolation { rule_id, violation }
+//!     +-- BudgetExhausted { resource }
+//!     +-- ProcessCrash { exit_code, signal }
+//!     +-- ProcessKilled { signal }
+//!     +-- ExplicitPin { actor, reason }
+//!     +-- QuarantineEntry { reason }
+//! ```
+//!
+//! # Trigger Categories
+//!
+//! Per AD-EVID-001, persistence is triggered on:
+//!
+//! 1. **Gate failures**: Security gate rejects an operation
+//! 2. **Policy violations**: Runtime policy check fails
+//! 3. **Budget exhaustion**: Episode exceeds resource limits
+//! 4. **Process abnormality**: Crash, signal, or forced termination
+//! 5. **Explicit pins**: Human or system requests evidence retention
+//! 6. **Quarantine entry**: Episode enters quarantine state
+//!
+//! # Security Model
+//!
+//! - Triggers are fail-closed: any unexpected termination preserves evidence
+//! - Normal completion does NOT trigger persistence (evidence is discarded)
+//! - All trigger events are recorded in the ledger for audit
+//!
+//! # Invariants
+//!
+//! - [INV-PT001] All trigger variants include sufficient context for audit
+//! - [INV-PT002] String fields are bounded by MAX_* constants
+//! - [INV-PT003] Triggers are serializable for ledger storage
+//!
+//! # Contract References
+//!
+//! - AD-EVID-001: Flight recorder and evidence persistence
+//! - CTR-1303: Bounded string lengths
+
+use serde::{Deserialize, Serialize};
+
+// =============================================================================
+// Constants (CTR-1303)
+// =============================================================================
+
+/// Maximum length for gate ID.
+pub const MAX_GATE_ID_LEN: usize = 128;
+
+/// Maximum length for rule ID.
+pub const MAX_RULE_ID_LEN: usize = 256;
+
+/// Maximum length for reason strings.
+pub const MAX_REASON_LEN: usize = 1024;
+
+/// Maximum length for resource names.
+pub const MAX_RESOURCE_LEN: usize = 64;
+
+/// Maximum length for actor IDs.
+pub const MAX_ACTOR_LEN: usize = 256;
+
+/// Maximum length for violation descriptions.
+pub const MAX_VIOLATION_LEN: usize = 2048;
+
+// =============================================================================
+// PersistTrigger
+// =============================================================================
+
+/// Trigger condition for flight recorder persistence.
+///
+/// These triggers determine when evidence should be persisted to the CAS
+/// rather than discarded. Per AD-EVID-001, evidence is retained on abnormal
+/// terminations to support debugging and incident investigation.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use apm2_daemon::evidence::trigger::PersistTrigger;
+///
+/// let trigger = PersistTrigger::gate_failure("pre-exec-gate", "capability denied");
+///
+/// assert!(trigger.is_security_related());
+/// assert_eq!(trigger.category(), TriggerCategory::Security);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+#[non_exhaustive]
+pub enum PersistTrigger {
+    /// Security gate rejected an operation.
+    ///
+    /// Gates are synchronous checkpoints that must pass before execution
+    /// continues. Gate failures indicate a security boundary was enforced.
+    GateFailure {
+        /// Identifier of the gate that failed.
+        gate_id: String,
+        /// Human-readable reason for failure.
+        reason: String,
+    },
+
+    /// Runtime policy check failed.
+    ///
+    /// Policy violations occur when a tool request violates runtime rules.
+    /// These are distinct from capability checks (pre-authorization) and
+    /// indicate runtime behavior exceeded policy bounds.
+    PolicyViolation {
+        /// Identifier of the rule that was violated.
+        rule_id: String,
+        /// Description of the violation.
+        violation: String,
+    },
+
+    /// Episode resource budget was exhausted.
+    ///
+    /// Budget exhaustion triggers when an episode exceeds its allocated
+    /// resources (tokens, tool calls, wall time, I/O bytes).
+    BudgetExhausted {
+        /// Name of the exhausted resource.
+        resource: String,
+        /// Amount consumed when exhaustion occurred.
+        consumed: u64,
+        /// Limit that was exceeded.
+        limit: u64,
+    },
+
+    /// Process terminated abnormally (crash).
+    ///
+    /// Crashes include non-zero exit codes and signal terminations.
+    ProcessCrash {
+        /// Exit code if process exited.
+        exit_code: Option<i32>,
+        /// Signal number if process was signaled.
+        signal: Option<i32>,
+        /// Signal name (e.g., "SIGSEGV") if available.
+        signal_name: Option<String>,
+    },
+
+    /// Process was forcibly killed.
+    ///
+    /// Distinct from crashes - this indicates intentional termination
+    /// by the system (e.g., SIGKILL from OOM killer or budget enforcement).
+    ProcessKilled {
+        /// Signal number used to kill the process.
+        signal: i32,
+        /// Signal name (e.g., "SIGKILL").
+        signal_name: String,
+        /// Reason for the kill (if known).
+        reason: Option<String>,
+    },
+
+    /// Explicit pin request from human or system.
+    ///
+    /// Allows manual evidence retention for debugging or investigation.
+    ExplicitPin {
+        /// Actor requesting the pin (human ID or system component).
+        actor: String,
+        /// Reason for pinning.
+        reason: String,
+    },
+
+    /// Episode entered quarantine state.
+    ///
+    /// Quarantine is a terminal state for episodes that encountered
+    /// security-relevant anomalies requiring investigation.
+    QuarantineEntry {
+        /// Reason for quarantine.
+        reason: String,
+    },
+
+    /// Watchdog timeout detected unresponsive episode.
+    ///
+    /// The episode failed to respond to health checks within the
+    /// configured timeout period.
+    WatchdogTimeout {
+        /// How long the episode was unresponsive (milliseconds).
+        unresponsive_ms: u64,
+        /// Configured timeout threshold (milliseconds).
+        threshold_ms: u64,
+    },
+
+    /// Internal error occurred during episode execution.
+    ///
+    /// These are daemon-internal errors, not application errors.
+    InternalError {
+        /// Error message.
+        message: String,
+        /// Error code if available.
+        code: Option<String>,
+    },
+}
+
+impl PersistTrigger {
+    // =========================================================================
+    // Constructors
+    // =========================================================================
+
+    /// Creates a gate failure trigger.
+    #[must_use]
+    pub fn gate_failure(gate_id: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::GateFailure {
+            gate_id: truncate_string(gate_id.into(), MAX_GATE_ID_LEN),
+            reason: truncate_string(reason.into(), MAX_REASON_LEN),
+        }
+    }
+
+    /// Creates a policy violation trigger.
+    #[must_use]
+    pub fn policy_violation(rule_id: impl Into<String>, violation: impl Into<String>) -> Self {
+        Self::PolicyViolation {
+            rule_id: truncate_string(rule_id.into(), MAX_RULE_ID_LEN),
+            violation: truncate_string(violation.into(), MAX_VIOLATION_LEN),
+        }
+    }
+
+    /// Creates a budget exhausted trigger.
+    #[must_use]
+    pub fn budget_exhausted(resource: impl Into<String>, consumed: u64, limit: u64) -> Self {
+        Self::BudgetExhausted {
+            resource: truncate_string(resource.into(), MAX_RESOURCE_LEN),
+            consumed,
+            limit,
+        }
+    }
+
+    /// Creates a process crash trigger from an exit code.
+    #[must_use]
+    pub const fn from_exit_code(code: i32) -> Self {
+        Self::ProcessCrash {
+            exit_code: Some(code),
+            signal: None,
+            signal_name: None,
+        }
+    }
+
+    /// Creates a process crash trigger from a signal.
+    #[must_use]
+    pub fn from_signal(signal: i32) -> Self {
+        Self::ProcessCrash {
+            exit_code: None,
+            signal: Some(signal),
+            signal_name: signal_name(signal),
+        }
+    }
+
+    /// Creates a process killed trigger.
+    #[must_use]
+    pub fn process_killed(signal: i32, reason: Option<String>) -> Self {
+        Self::ProcessKilled {
+            signal,
+            signal_name: signal_name(signal).unwrap_or_else(|| format!("SIG{signal}")),
+            reason: reason.map(|r| truncate_string(r, MAX_REASON_LEN)),
+        }
+    }
+
+    /// Creates an explicit pin trigger.
+    #[must_use]
+    pub fn explicit_pin(actor: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::ExplicitPin {
+            actor: truncate_string(actor.into(), MAX_ACTOR_LEN),
+            reason: truncate_string(reason.into(), MAX_REASON_LEN),
+        }
+    }
+
+    /// Creates a quarantine entry trigger.
+    #[must_use]
+    pub fn quarantine(reason: impl Into<String>) -> Self {
+        Self::QuarantineEntry {
+            reason: truncate_string(reason.into(), MAX_REASON_LEN),
+        }
+    }
+
+    /// Creates a watchdog timeout trigger.
+    #[must_use]
+    pub const fn watchdog_timeout(unresponsive_ms: u64, threshold_ms: u64) -> Self {
+        Self::WatchdogTimeout {
+            unresponsive_ms,
+            threshold_ms,
+        }
+    }
+
+    /// Creates an internal error trigger.
+    #[must_use]
+    pub fn internal_error(message: impl Into<String>, code: Option<String>) -> Self {
+        Self::InternalError {
+            message: truncate_string(message.into(), MAX_REASON_LEN),
+            code: code.map(|c| truncate_string(c, MAX_GATE_ID_LEN)),
+        }
+    }
+
+    // =========================================================================
+    // Accessors
+    // =========================================================================
+
+    /// Returns the trigger category.
+    #[must_use]
+    pub const fn category(&self) -> TriggerCategory {
+        match self {
+            Self::GateFailure { .. }
+            | Self::PolicyViolation { .. }
+            | Self::QuarantineEntry { .. } => TriggerCategory::Security,
+            Self::BudgetExhausted { .. } | Self::WatchdogTimeout { .. } => {
+                TriggerCategory::Resource
+            },
+            Self::ProcessCrash { .. } | Self::ProcessKilled { .. } => TriggerCategory::Process,
+            Self::ExplicitPin { .. } => TriggerCategory::Manual,
+            Self::InternalError { .. } => TriggerCategory::Internal,
+        }
+    }
+
+    /// Returns `true` if this trigger is security-related.
+    #[must_use]
+    pub const fn is_security_related(&self) -> bool {
+        matches!(self.category(), TriggerCategory::Security)
+    }
+
+    /// Returns `true` if this trigger requires immediate investigation.
+    ///
+    /// High-severity triggers that should be escalated.
+    #[must_use]
+    pub const fn requires_immediate_attention(&self) -> bool {
+        matches!(
+            self,
+            Self::GateFailure { .. }
+                | Self::PolicyViolation { .. }
+                | Self::QuarantineEntry { .. }
+                | Self::ProcessKilled { .. }
+        )
+    }
+
+    /// Returns the trigger type as a string identifier.
+    #[must_use]
+    pub const fn trigger_type(&self) -> &'static str {
+        match self {
+            Self::GateFailure { .. } => "gate_failure",
+            Self::PolicyViolation { .. } => "policy_violation",
+            Self::BudgetExhausted { .. } => "budget_exhausted",
+            Self::ProcessCrash { .. } => "process_crash",
+            Self::ProcessKilled { .. } => "process_killed",
+            Self::ExplicitPin { .. } => "explicit_pin",
+            Self::QuarantineEntry { .. } => "quarantine_entry",
+            Self::WatchdogTimeout { .. } => "watchdog_timeout",
+            Self::InternalError { .. } => "internal_error",
+        }
+    }
+
+    /// Returns a human-readable summary of the trigger.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        match self {
+            Self::GateFailure { gate_id, reason } => {
+                format!("Gate '{gate_id}' failed: {reason}")
+            },
+            Self::PolicyViolation { rule_id, violation } => {
+                format!("Policy rule '{rule_id}' violated: {violation}")
+            },
+            Self::BudgetExhausted {
+                resource,
+                consumed,
+                limit,
+            } => {
+                format!("Budget exhausted: {resource} ({consumed}/{limit})")
+            },
+            Self::ProcessCrash {
+                exit_code,
+                signal,
+                signal_name,
+            } => match (signal, exit_code) {
+                (Some(sig), _) => {
+                    let name = signal_name.as_deref().unwrap_or("unknown");
+                    format!("Process crashed with signal {sig} ({name})")
+                },
+                (None, Some(code)) => format!("Process crashed with exit code {code}"),
+                (None, None) => "Process crashed".to_string(),
+            },
+            Self::ProcessKilled {
+                signal,
+                signal_name,
+                reason,
+            } => {
+                let reason_str = reason.as_deref().unwrap_or("no reason provided");
+                format!("Process killed with signal {signal} ({signal_name}): {reason_str}")
+            },
+            Self::ExplicitPin { actor, reason } => {
+                format!("Explicitly pinned by '{actor}': {reason}")
+            },
+            Self::QuarantineEntry { reason } => {
+                format!("Entered quarantine: {reason}")
+            },
+            Self::WatchdogTimeout {
+                unresponsive_ms,
+                threshold_ms,
+            } => {
+                format!(
+                    "Watchdog timeout: unresponsive for {unresponsive_ms}ms (threshold: {threshold_ms}ms)"
+                )
+            },
+            Self::InternalError { message, code } => code.as_ref().map_or_else(
+                || format!("Internal error: {message}"),
+                |c| format!("Internal error [{c}]: {message}"),
+            ),
+        }
+    }
+}
+
+// =============================================================================
+// TriggerCategory
+// =============================================================================
+
+/// Category of persistence trigger.
+///
+/// Used for filtering and prioritization of triggers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TriggerCategory {
+    /// Security-related triggers (gates, policies, quarantine).
+    Security,
+
+    /// Resource-related triggers (budget, watchdog).
+    Resource,
+
+    /// Process-related triggers (crash, kill).
+    Process,
+
+    /// Manual triggers (explicit pins).
+    Manual,
+
+    /// Internal daemon errors.
+    Internal,
+}
+
+impl TriggerCategory {
+    /// Returns the category name as a string.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Security => "security",
+            Self::Resource => "resource",
+            Self::Process => "process",
+            Self::Manual => "manual",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+impl std::fmt::Display for TriggerCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/// Truncates a string to the maximum length, preserving valid UTF-8.
+fn truncate_string(s: String, max_len: usize) -> String {
+    if s.len() <= max_len {
+        return s;
+    }
+
+    // Find a valid UTF-8 boundary
+    let mut end = max_len;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+
+    s[..end].to_string()
+}
+
+/// Returns the signal name for common signals.
+fn signal_name(signal: i32) -> Option<String> {
+    let name = match signal {
+        1 => "SIGHUP",
+        2 => "SIGINT",
+        3 => "SIGQUIT",
+        4 => "SIGILL",
+        5 => "SIGTRAP",
+        6 => "SIGABRT",
+        7 => "SIGBUS",
+        8 => "SIGFPE",
+        9 => "SIGKILL",
+        10 => "SIGUSR1",
+        11 => "SIGSEGV",
+        12 => "SIGUSR2",
+        13 => "SIGPIPE",
+        14 => "SIGALRM",
+        15 => "SIGTERM",
+        _ => return None,
+    };
+    Some(name.to_string())
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gate_failure_trigger() {
+        let trigger = PersistTrigger::gate_failure("auth-gate", "invalid token");
+
+        assert_eq!(trigger.trigger_type(), "gate_failure");
+        assert_eq!(trigger.category(), TriggerCategory::Security);
+        assert!(trigger.is_security_related());
+        assert!(trigger.requires_immediate_attention());
+        assert!(trigger.summary().contains("auth-gate"));
+    }
+
+    #[test]
+    fn test_policy_violation_trigger() {
+        let trigger = PersistTrigger::policy_violation("no-network", "attempted DNS lookup");
+
+        assert_eq!(trigger.trigger_type(), "policy_violation");
+        assert_eq!(trigger.category(), TriggerCategory::Security);
+        assert!(trigger.is_security_related());
+    }
+
+    #[test]
+    fn test_budget_exhausted_trigger() {
+        let trigger = PersistTrigger::budget_exhausted("tokens", 10000, 5000);
+
+        assert_eq!(trigger.trigger_type(), "budget_exhausted");
+        assert_eq!(trigger.category(), TriggerCategory::Resource);
+        assert!(!trigger.is_security_related());
+        assert!(trigger.summary().contains("10000"));
+        assert!(trigger.summary().contains("5000"));
+    }
+
+    #[test]
+    fn test_process_crash_exit_code() {
+        let trigger = PersistTrigger::from_exit_code(1);
+
+        assert_eq!(trigger.trigger_type(), "process_crash");
+        assert_eq!(trigger.category(), TriggerCategory::Process);
+        assert!(trigger.summary().contains("exit code 1"));
+    }
+
+    #[test]
+    fn test_process_crash_signal() {
+        let trigger = PersistTrigger::from_signal(11); // SIGSEGV
+
+        assert_eq!(trigger.trigger_type(), "process_crash");
+        assert!(trigger.summary().contains("SIGSEGV"));
+    }
+
+    #[test]
+    fn test_process_killed_trigger() {
+        let trigger = PersistTrigger::process_killed(9, Some("OOM killer".to_string()));
+
+        assert_eq!(trigger.trigger_type(), "process_killed");
+        assert!(trigger.requires_immediate_attention());
+        assert!(trigger.summary().contains("SIGKILL"));
+        assert!(trigger.summary().contains("OOM killer"));
+    }
+
+    #[test]
+    fn test_explicit_pin_trigger() {
+        let trigger = PersistTrigger::explicit_pin("user@example.com", "investigating issue");
+
+        assert_eq!(trigger.trigger_type(), "explicit_pin");
+        assert_eq!(trigger.category(), TriggerCategory::Manual);
+        assert!(!trigger.is_security_related());
+    }
+
+    #[test]
+    fn test_quarantine_trigger() {
+        let trigger = PersistTrigger::quarantine("suspicious network activity");
+
+        assert_eq!(trigger.trigger_type(), "quarantine_entry");
+        assert!(trigger.is_security_related());
+        assert!(trigger.requires_immediate_attention());
+    }
+
+    #[test]
+    fn test_watchdog_timeout_trigger() {
+        let trigger = PersistTrigger::watchdog_timeout(30000, 10000);
+
+        assert_eq!(trigger.trigger_type(), "watchdog_timeout");
+        assert_eq!(trigger.category(), TriggerCategory::Resource);
+        assert!(trigger.summary().contains("30000ms"));
+    }
+
+    #[test]
+    fn test_internal_error_trigger() {
+        let trigger =
+            PersistTrigger::internal_error("database connection failed", Some("E001".to_string()));
+
+        assert_eq!(trigger.trigger_type(), "internal_error");
+        assert_eq!(trigger.category(), TriggerCategory::Internal);
+        assert!(trigger.summary().contains("E001"));
+    }
+
+    #[test]
+    fn test_trigger_serialization() {
+        let trigger = PersistTrigger::gate_failure("test-gate", "test reason");
+        let json = serde_json::to_string(&trigger).unwrap();
+        let deserialized: PersistTrigger = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(trigger, deserialized);
+    }
+
+    #[test]
+    fn test_trigger_json_format() {
+        let trigger = PersistTrigger::gate_failure("test-gate", "test reason");
+        let json = serde_json::to_string_pretty(&trigger).unwrap();
+
+        assert!(json.contains("\"type\": \"gate_failure\""));
+        assert!(json.contains("\"gate_id\": \"test-gate\""));
+    }
+
+    /// SECURITY: Verify unknown fields are rejected.
+    #[test]
+    fn test_trigger_rejects_unknown_fields() {
+        let json = r#"{
+            "type": "gate_failure",
+            "gate_id": "test",
+            "reason": "test",
+            "malicious": "attack"
+        }"#;
+
+        let result: Result<PersistTrigger, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "should reject unknown fields");
+    }
+
+    #[test]
+    fn test_string_truncation() {
+        let long_string = "a".repeat(MAX_REASON_LEN * 2);
+        let trigger = PersistTrigger::gate_failure("gate", &long_string);
+
+        if let PersistTrigger::GateFailure { reason, .. } = trigger {
+            assert!(reason.len() <= MAX_REASON_LEN);
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn test_trigger_category_display() {
+        assert_eq!(TriggerCategory::Security.to_string(), "security");
+        assert_eq!(TriggerCategory::Resource.to_string(), "resource");
+        assert_eq!(TriggerCategory::Process.to_string(), "process");
+        assert_eq!(TriggerCategory::Manual.to_string(), "manual");
+        assert_eq!(TriggerCategory::Internal.to_string(), "internal");
+    }
+
+    #[test]
+    fn test_all_trigger_types_have_summaries() {
+        let triggers = vec![
+            PersistTrigger::gate_failure("gate", "reason"),
+            PersistTrigger::policy_violation("rule", "violation"),
+            PersistTrigger::budget_exhausted("resource", 100, 50),
+            PersistTrigger::from_exit_code(1),
+            PersistTrigger::from_signal(9),
+            PersistTrigger::process_killed(9, None),
+            PersistTrigger::explicit_pin("actor", "reason"),
+            PersistTrigger::quarantine("reason"),
+            PersistTrigger::watchdog_timeout(1000, 500),
+            PersistTrigger::internal_error("message", None),
+        ];
+
+        for trigger in triggers {
+            let summary = trigger.summary();
+            assert!(!summary.is_empty(), "trigger {trigger:?} has empty summary");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements flight recorder per AD-EVID-001 with per-episode ring buffers for PTY output, tool I/O, and telemetry frames. Buffer sizes are configurable per risk tier with persistence triggered on failures/violations.

Key components:

- **RecorderConfig** (`config.rs`): Per-risk-tier buffer size configuration
  - Tier 1: ~1.75MB (pty=256, tool=256, telemetry=1024 items)
  - Tier 2: ~7MB (pty=1024, tool=1024, telemetry=4096 items)
  - Tier 3+: ~28MB (pty=4096, tool=4096, telemetry=16384 items)

- **PersistTrigger** (`trigger.rs`): Defines conditions for evidence persistence
  - Gate failures, policy violations, budget exhaustion
  - Process crashes/kills, explicit pins, quarantine entry
  - Watchdog timeouts, internal errors

- **FlightRecorder** (`recorder.rs`): Main implementation with:
  - Three bounded ring buffers (PTY, tool, telemetry)
  - `push_*` methods for each evidence type
  - `persist()` flushes to CAS with content hashes
  - `clear()` empties all buffers on normal termination

## Security Model

- **Fail-closed**: Abnormal terminations preserve evidence
- **Content-addressed**: Evidence integrity via BLAKE3 hashes
- **Bounded**: Configurable `MAX_BUFFER_CAPACITY` prevents memory exhaustion
- **Strict deserialization**: `deny_unknown_fields` on all serializable types

## Test Plan

- [x] UT-00170-01: Ring buffer bounds (3 tests) - `cargo test -p apm2-daemon recorder_bounds`
- [x] UT-00170-02: Persistence to CAS (3 tests) - `cargo test -p apm2-daemon recorder_persist`
- [x] UT-00170-03: Tier configuration (14 tests) - `cargo test -p apm2-daemon recorder_config`
- [x] Additional serialization, lifecycle, and trigger tests (31 total tests)
- [x] All apm2-daemon tests pass: `cargo test -p apm2-daemon`
- [x] Clippy clean: `cargo clippy -p apm2-daemon -- -D warnings`
- [x] Format clean: `cargo fmt -p apm2-daemon -- --check`

## Files Changed

### New Files
- `crates/apm2-daemon/src/evidence/config.rs` - RecorderConfig per risk tier
- `crates/apm2-daemon/src/evidence/trigger.rs` - Trigger conditions for persistence
- `crates/apm2-daemon/src/evidence/recorder.rs` - FlightRecorder implementation

### Modified Files
- `crates/apm2-daemon/src/evidence/mod.rs` - Export recorder, config, trigger modules

## Contract References

- AD-EVID-001: Flight recorder and ring buffers
- CTR-1303: Bounded collections with MAX_* constants

Generated with [Claude Code](https://claude.ai/code)