### PR TITLE
feat(TCK-00175): implement E2E lifecycle and budget tests

### DIFF
--- a/crates/apm2-daemon/tests/common/daemon.rs
+++ b/crates/apm2-daemon/tests/common/daemon.rs
@@ -1,0 +1,403 @@
+//! `TestDaemon` helper for E2E episode tests.
+//!
+//! This module provides the `TestDaemon` struct that creates an isolated
+//! test environment with an `EpisodeRuntime` instance for E2E testing.
+//!
+//! # Architecture
+//!
+//! Unlike full daemon integration tests that spawn processes over UDS,
+//! these E2E tests focus on the episode lifecycle and budget enforcement
+//! by directly interacting with `EpisodeRuntime`. This approach:
+//!
+//! 1. Avoids unnecessary process spawning overhead
+//! 2. Enables deterministic timing tests (HARD-TIME)
+//! 3. Focuses on the episode lifecycle state machine
+//!
+//! # Contract References
+//!
+//! - TCK-00175: E2E lifecycle and budget tests
+//! - AD-EPISODE-002: Episode state machine
+//! - AD-LAYER-001: `EpisodeRuntime` as plant controller
+
+use std::sync::Arc;
+
+use apm2_daemon::episode::{
+    BudgetDelta, BudgetSnapshot, BudgetTracker, EpisodeBudget, EpisodeEvent, EpisodeId,
+    EpisodeRuntime, EpisodeRuntimeConfig, EpisodeState, QuarantineReason, SessionHandle,
+    StopSignal, TerminationClass,
+};
+use tempfile::TempDir;
+
+/// Test timestamp base: 2024-01-01 00:00:00 UTC in nanoseconds.
+pub const TEST_TIMESTAMP_NS: u64 = 1_704_067_200_000_000_000;
+
+/// One second in nanoseconds.
+pub const ONE_SEC_NS: u64 = 1_000_000_000;
+
+/// One millisecond in nanoseconds.
+pub const ONE_MS_NS: u64 = 1_000_000;
+
+/// Test helper for E2E episode lifecycle tests.
+///
+/// `TestDaemon` provides an isolated test environment with an `EpisodeRuntime`
+/// instance. It manages a temporary directory for any file operations and
+/// provides convenient methods for common test operations.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use crate::common::TestDaemon;
+///
+/// #[tokio::test]
+/// async fn test_episode_lifecycle() {
+///     let daemon = TestDaemon::start();
+///
+///     // Create an episode
+///     let episode_id = daemon.create_episode().await.unwrap();
+///
+///     // Start the episode
+///     let handle = daemon.start_episode(&episode_id).await.unwrap();
+///
+///     // Stop the episode
+///     daemon.stop_episode(&episode_id, TerminationClass::Success).await.unwrap();
+/// }
+/// ```
+#[derive(Debug)]
+pub struct TestDaemon {
+    /// The episode runtime instance.
+    runtime: Arc<EpisodeRuntime>,
+    /// Temporary directory for test isolation.
+    #[allow(dead_code)]
+    temp_dir: TempDir,
+    /// Monotonic timestamp counter for deterministic timing.
+    current_timestamp_ns: std::sync::atomic::AtomicU64,
+    /// Episode sequence number for unique test envelopes.
+    episode_seq: std::sync::atomic::AtomicU64,
+}
+
+#[allow(dead_code)]
+impl TestDaemon {
+    /// Creates a new test daemon with default configuration.
+    ///
+    /// This creates an isolated test environment with:
+    /// - An `EpisodeRuntime` with default configuration
+    /// - A temporary directory for file operations
+    /// - Deterministic timestamp generation
+    #[must_use]
+    pub fn start() -> Self {
+        Self::with_config(EpisodeRuntimeConfig::default())
+    }
+
+    /// Creates a new test daemon with custom configuration.
+    #[must_use]
+    pub fn with_config(config: EpisodeRuntimeConfig) -> Self {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let runtime = Arc::new(EpisodeRuntime::new(config));
+
+        Self {
+            runtime,
+            temp_dir,
+            current_timestamp_ns: std::sync::atomic::AtomicU64::new(TEST_TIMESTAMP_NS),
+            episode_seq: std::sync::atomic::AtomicU64::new(1),
+        }
+    }
+
+    /// Creates a test daemon with a limited number of concurrent episodes.
+    ///
+    /// Useful for testing limit enforcement.
+    #[must_use]
+    pub fn with_max_episodes(max: usize) -> Self {
+        let config = EpisodeRuntimeConfig::default()
+            .with_max_concurrent_episodes(max)
+            .with_emit_events(true);
+        Self::with_config(config)
+    }
+
+    /// Returns the current test timestamp in nanoseconds.
+    #[must_use]
+    pub fn current_timestamp_ns(&self) -> u64 {
+        self.current_timestamp_ns
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Advances the test timestamp by the given duration in nanoseconds.
+    ///
+    /// Returns the new timestamp.
+    pub fn advance_time_ns(&self, delta_ns: u64) -> u64 {
+        self.current_timestamp_ns
+            .fetch_add(delta_ns, std::sync::atomic::Ordering::Relaxed)
+            + delta_ns
+    }
+
+    /// Advances the test timestamp by the given duration in milliseconds.
+    ///
+    /// Returns the new timestamp.
+    pub fn advance_time_ms(&self, delta_ms: u64) -> u64 {
+        self.advance_time_ns(delta_ms * ONE_MS_NS)
+    }
+
+    /// Advances the test timestamp by one second.
+    ///
+    /// Returns the new timestamp.
+    pub fn advance_one_second(&self) -> u64 {
+        self.advance_time_ns(ONE_SEC_NS)
+    }
+
+    /// Generates a unique test envelope hash.
+    ///
+    /// The hash incorporates a sequence number to ensure uniqueness.
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn test_envelope_hash(&self) -> [u8; 32] {
+        let seq = self
+            .episode_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut hash = [0u8; 32];
+        hash[0..8].copy_from_slice(&seq.to_le_bytes());
+        // Fill remaining bytes with a pattern for easier debugging
+        // Truncation is safe: i ranges from 8..32, fitting in u8
+        for (i, byte) in hash.iter_mut().enumerate().skip(8) {
+            *byte = (i as u8).wrapping_mul(17);
+        }
+        hash
+    }
+
+    /// Creates a new episode with a unique envelope hash.
+    ///
+    /// Returns the episode ID on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the runtime rejects the creation (e.g., limit
+    /// reached).
+    pub async fn create_episode(&self) -> Result<EpisodeId, apm2_daemon::episode::EpisodeError> {
+        let envelope_hash = self.test_envelope_hash();
+        let timestamp = self.current_timestamp_ns();
+        self.runtime.create(envelope_hash, timestamp).await
+    }
+
+    /// Starts an episode with a generated lease ID.
+    ///
+    /// Advances the timestamp by 1ms before starting.
+    ///
+    /// Returns the session handle on success.
+    pub async fn start_episode(
+        &self,
+        episode_id: &EpisodeId,
+    ) -> Result<SessionHandle, apm2_daemon::episode::EpisodeError> {
+        let timestamp = self.advance_time_ms(1);
+        let lease_id = format!("lease-{}", self.current_timestamp_ns());
+        self.runtime.start(episode_id, lease_id, timestamp).await
+    }
+
+    /// Starts an episode with a specific lease ID.
+    ///
+    /// Advances the timestamp by 1ms before starting.
+    pub async fn start_episode_with_lease(
+        &self,
+        episode_id: &EpisodeId,
+        lease_id: impl Into<String>,
+    ) -> Result<SessionHandle, apm2_daemon::episode::EpisodeError> {
+        let timestamp = self.advance_time_ms(1);
+        self.runtime.start(episode_id, lease_id, timestamp).await
+    }
+
+    /// Stops an episode with the specified termination class.
+    ///
+    /// Advances the timestamp by 1ms before stopping.
+    pub async fn stop_episode(
+        &self,
+        episode_id: &EpisodeId,
+        termination_class: TerminationClass,
+    ) -> Result<(), apm2_daemon::episode::EpisodeError> {
+        let timestamp = self.advance_time_ms(1);
+        self.runtime
+            .stop(episode_id, termination_class, timestamp)
+            .await
+    }
+
+    /// Quarantines an episode with the specified reason.
+    ///
+    /// Advances the timestamp by 1ms before quarantining.
+    pub async fn quarantine_episode(
+        &self,
+        episode_id: &EpisodeId,
+        reason: QuarantineReason,
+    ) -> Result<(), apm2_daemon::episode::EpisodeError> {
+        let timestamp = self.advance_time_ms(1);
+        self.runtime.quarantine(episode_id, reason, timestamp).await
+    }
+
+    /// Signals a running episode.
+    pub async fn signal_episode(
+        &self,
+        episode_id: &EpisodeId,
+        signal: StopSignal,
+    ) -> Result<(), apm2_daemon::episode::EpisodeError> {
+        self.runtime.signal(episode_id, signal).await
+    }
+
+    /// Observes the current state of an episode.
+    pub async fn observe_episode(
+        &self,
+        episode_id: &EpisodeId,
+    ) -> Result<EpisodeState, apm2_daemon::episode::EpisodeError> {
+        self.runtime.observe(episode_id).await
+    }
+
+    /// Drains all emitted events from the runtime.
+    pub async fn drain_events(&self) -> Vec<EpisodeEvent> {
+        self.runtime.drain_events().await
+    }
+
+    /// Returns the count of active (non-terminal) episodes.
+    pub async fn active_count(&self) -> usize {
+        self.runtime.active_count().await
+    }
+
+    /// Returns the total count of tracked episodes.
+    pub async fn total_count(&self) -> usize {
+        self.runtime.total_count().await
+    }
+
+    /// Cleans up terminal episodes from tracking.
+    pub async fn cleanup_terminal(&self) -> usize {
+        self.runtime.cleanup_terminal().await
+    }
+
+    /// Creates a budget tracker with the specified limits.
+    #[must_use]
+    pub fn create_budget_tracker(budget: EpisodeBudget) -> BudgetTracker {
+        BudgetTracker::from_envelope(budget)
+    }
+
+    /// Creates a budget tracker with default test limits.
+    ///
+    /// Default limits:
+    /// - `tokens`: 10,000
+    /// - `tool_calls`: 100
+    /// - `wall_ms`: 60,000 (1 minute)
+    /// - `cpu_ms`: 30,000 (30 seconds)
+    /// - `bytes_io`: 1,000,000 (1 MB)
+    /// - `evidence_bytes`: 100,000 (100 KB)
+    #[must_use]
+    pub fn create_test_budget_tracker() -> BudgetTracker {
+        let budget = EpisodeBudget::builder()
+            .tokens(10_000)
+            .tool_calls(100)
+            .wall_ms(60_000)
+            .cpu_ms(30_000)
+            .bytes_io(1_000_000)
+            .evidence_bytes(100_000)
+            .build();
+        BudgetTracker::from_envelope(budget)
+    }
+
+    /// Charges a budget delta to the tracker and returns the result.
+    ///
+    /// This is a convenience method for budget exhaustion tests.
+    pub fn charge_budget(
+        tracker: &BudgetTracker,
+        delta: &BudgetDelta,
+    ) -> Result<(), apm2_daemon::episode::BudgetExhaustedError> {
+        tracker.charge(delta)
+    }
+
+    /// Returns a snapshot of consumed resources from the tracker.
+    #[must_use]
+    pub fn consumed_budget(tracker: &BudgetTracker) -> BudgetSnapshot {
+        tracker.consumed()
+    }
+
+    /// Returns the remaining budget from the tracker.
+    #[must_use]
+    pub fn remaining_budget(tracker: &BudgetTracker) -> EpisodeBudget {
+        tracker.remaining()
+    }
+
+    /// Checks if the tracker's budget is exhausted.
+    #[must_use]
+    pub fn is_budget_exhausted(tracker: &BudgetTracker) -> bool {
+        tracker.is_exhausted()
+    }
+}
+
+impl Default for TestDaemon {
+    fn default() -> Self {
+        Self::start()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_daemon_creation() {
+        let daemon = TestDaemon::start();
+        assert_eq!(daemon.active_count().await, 0);
+        assert_eq!(daemon.total_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_daemon_timestamp_advancement() {
+        let daemon = TestDaemon::start();
+        let initial = daemon.current_timestamp_ns();
+
+        daemon.advance_one_second();
+        assert_eq!(daemon.current_timestamp_ns(), initial + ONE_SEC_NS);
+
+        daemon.advance_time_ms(500);
+        assert_eq!(
+            daemon.current_timestamp_ns(),
+            initial + ONE_SEC_NS + 500 * ONE_MS_NS
+        );
+    }
+
+    #[tokio::test]
+    async fn test_daemon_unique_envelope_hashes() {
+        let daemon = TestDaemon::start();
+
+        let hash1 = daemon.test_envelope_hash();
+        let hash2 = daemon.test_envelope_hash();
+        let hash3 = daemon.test_envelope_hash();
+
+        // All hashes should be unique
+        assert_ne!(hash1, hash2);
+        assert_ne!(hash2, hash3);
+        assert_ne!(hash1, hash3);
+    }
+
+    #[tokio::test]
+    async fn test_daemon_episode_lifecycle() {
+        let daemon = TestDaemon::start();
+
+        // Create
+        let episode_id = daemon.create_episode().await.unwrap();
+        assert_eq!(daemon.active_count().await, 1);
+
+        // Start
+        let handle = daemon.start_episode(&episode_id).await.unwrap();
+        assert!(!handle.should_stop());
+
+        // Stop
+        daemon
+            .stop_episode(&episode_id, TerminationClass::Success)
+            .await
+            .unwrap();
+        assert_eq!(daemon.active_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_daemon_budget_tracker() {
+        let tracker = TestDaemon::create_test_budget_tracker();
+
+        assert!(!TestDaemon::is_budget_exhausted(&tracker));
+
+        let delta = BudgetDelta::single_call().with_tokens(5_000);
+        TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+        let remaining = TestDaemon::remaining_budget(&tracker);
+        assert_eq!(remaining.tokens(), 5_000);
+    }
+}

--- a/crates/apm2-daemon/tests/common/mod.rs
+++ b/crates/apm2-daemon/tests/common/mod.rs
@@ -1,0 +1,19 @@
+//! Common test utilities for E2E daemon tests.
+//!
+//! This module provides shared test infrastructure for integration tests
+//! including `TestDaemon` for isolated daemon instances.
+//!
+//! # Test Isolation
+//!
+//! Each test uses `tempfile` for isolation, ensuring tests don't interfere
+//! with each other.
+//!
+//! # Contract References
+//!
+//! - TCK-00175: E2E lifecycle and budget tests
+//! - REQ-EPISODE-001: Episode envelope requirements
+//! - REQ-DAEMON-001: Daemon requirements
+
+pub mod daemon;
+
+pub use daemon::TestDaemon;

--- a/crates/apm2-daemon/tests/e2e_budget.rs
+++ b/crates/apm2-daemon/tests/e2e_budget.rs
@@ -1,0 +1,715 @@
+//! End-to-end budget exhaustion tests.
+//!
+//! This module tests budget enforcement and exhaustion scenarios:
+//! - Token budget exhaustion
+//! - Tool calls budget exhaustion
+//! - Wall time exhaustion
+//! - CPU time exhaustion
+//! - I/O bytes exhaustion
+//! - Evidence bytes exhaustion
+//! - Budget exhausted termination class
+//! - Stop signal propagation
+//!
+//! # Contract References
+//!
+//! - TCK-00175: E2E lifecycle and budget tests
+//! - TCK-00165: Tool execution and budget charging
+//! - CTR-2504: Defensive time handling
+//!
+//! # Test Coverage
+//!
+//! | Test ID        | Description                          |
+//! |----------------|--------------------------------------|
+//! | E2E-00175-02   | Budget exhaustion E2E                |
+//! | UT-BG-001      | Token exhaustion                     |
+//! | UT-BG-002      | Tool calls exhaustion                |
+//! | UT-BG-003      | Wall time exhaustion                 |
+//! | UT-BG-004      | CPU time exhaustion                  |
+//! | UT-BG-005      | I/O bytes exhaustion                 |
+//! | UT-BG-006      | Evidence bytes exhaustion            |
+//! | UT-BG-007      | Budget exhausted termination         |
+//! | UT-BG-008      | Concurrent budget charging           |
+
+mod common;
+
+use apm2_daemon::episode::{
+    BudgetDelta, BudgetExhaustedError, BudgetTracker, EpisodeBudget, StopSignal, TerminationClass,
+};
+use common::TestDaemon;
+
+// =============================================================================
+// UT-BG-001: Token Budget Exhaustion
+// =============================================================================
+
+/// Test token budget exhaustion.
+#[tokio::test]
+async fn test_token_budget_exhaustion() {
+    let budget = EpisodeBudget::builder()
+        .tokens(1000)
+        .tool_calls(100)
+        .build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Charge 800 tokens - should succeed
+    let delta = BudgetDelta::single_call().with_tokens(800);
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    // Verify remaining
+    let remaining = TestDaemon::remaining_budget(&tracker);
+    assert_eq!(remaining.tokens(), 200);
+
+    // Charge 300 more tokens - should fail (exceeds remaining)
+    let delta = BudgetDelta::single_call().with_tokens(300);
+    let result = TestDaemon::charge_budget(&tracker, &delta);
+
+    assert!(matches!(
+        result,
+        Err(BudgetExhaustedError::Tokens {
+            requested: 300,
+            remaining: 200
+        })
+    ));
+}
+
+/// Test token budget exactly exhausted.
+#[tokio::test]
+async fn test_token_budget_exact_exhaustion() {
+    let budget = EpisodeBudget::builder().tokens(500).build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Charge exactly the limit
+    let delta = BudgetDelta::single_call().with_tokens(500);
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    assert!(tracker.is_tokens_exhausted());
+    assert!(tracker.is_exhausted());
+
+    // Any further charge should fail
+    let delta = BudgetDelta::single_call().with_tokens(1);
+    let result = TestDaemon::charge_budget(&tracker, &delta);
+    assert!(matches!(result, Err(BudgetExhaustedError::Tokens { .. })));
+}
+
+/// Test token budget with multiple small charges.
+#[tokio::test]
+async fn test_token_budget_incremental_exhaustion() {
+    let budget = EpisodeBudget::builder().tokens(100).build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Charge 10 tokens 10 times
+    for _ in 0..10 {
+        let delta = BudgetDelta::single_call().with_tokens(10);
+        TestDaemon::charge_budget(&tracker, &delta).unwrap();
+    }
+
+    assert!(tracker.is_tokens_exhausted());
+
+    // 11th charge should fail
+    let delta = BudgetDelta::single_call().with_tokens(10);
+    let result = TestDaemon::charge_budget(&tracker, &delta);
+    assert!(matches!(result, Err(BudgetExhaustedError::Tokens { .. })));
+}
+
+// =============================================================================
+// UT-BG-002: Tool Calls Budget Exhaustion
+// =============================================================================
+
+/// Test tool calls budget exhaustion.
+#[tokio::test]
+async fn test_tool_calls_budget_exhaustion() {
+    let budget = EpisodeBudget::builder().tool_calls(5).build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Make 5 tool calls
+    for _ in 0..5 {
+        let delta = BudgetDelta::single_call();
+        TestDaemon::charge_budget(&tracker, &delta).unwrap();
+    }
+
+    assert!(tracker.is_tool_calls_exhausted());
+    assert!(tracker.is_exhausted());
+
+    // 6th call should fail
+    let delta = BudgetDelta::single_call();
+    let result = TestDaemon::charge_budget(&tracker, &delta);
+    assert!(matches!(
+        result,
+        Err(BudgetExhaustedError::ToolCalls {
+            requested: 1,
+            remaining: 0
+        })
+    ));
+}
+
+/// Test tool calls budget with batch calls.
+#[tokio::test]
+async fn test_tool_calls_batch_exhaustion() {
+    let budget = EpisodeBudget::builder().tool_calls(10).build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Batch of 3 calls
+    let delta = BudgetDelta {
+        tool_calls: 3,
+        ..Default::default()
+    };
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    // Batch of 5 calls
+    let delta = BudgetDelta {
+        tool_calls: 5,
+        ..Default::default()
+    };
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    // Batch of 3 should fail (only 2 remaining)
+    let delta = BudgetDelta {
+        tool_calls: 3,
+        ..Default::default()
+    };
+    let result = TestDaemon::charge_budget(&tracker, &delta);
+    assert!(matches!(
+        result,
+        Err(BudgetExhaustedError::ToolCalls {
+            requested: 3,
+            remaining: 2
+        })
+    ));
+}
+
+// =============================================================================
+// UT-BG-003: Wall Time Exhaustion
+// =============================================================================
+
+/// Test wall time budget exhaustion.
+#[tokio::test]
+async fn test_wall_time_budget_exhaustion() {
+    let budget = EpisodeBudget::builder().wall_ms(60_000).build(); // 1 minute
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Charge 50 seconds
+    let delta = BudgetDelta::single_call().with_wall_ms(50_000);
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    // Charge 15 more seconds - should fail
+    let delta = BudgetDelta::single_call().with_wall_ms(15_000);
+    let result = TestDaemon::charge_budget(&tracker, &delta);
+
+    assert!(matches!(
+        result,
+        Err(BudgetExhaustedError::WallTime {
+            requested: 15_000,
+            remaining: 10_000
+        })
+    ));
+}
+
+/// Test wall time exact exhaustion.
+#[tokio::test]
+async fn test_wall_time_exact_exhaustion() {
+    let budget = EpisodeBudget::builder().wall_ms(1000).build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Charge exactly 1000ms
+    let delta = BudgetDelta::single_call().with_wall_ms(1000);
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    assert!(tracker.is_wall_time_exhausted());
+    assert!(tracker.is_exhausted());
+}
+
+// =============================================================================
+// UT-BG-004: CPU Time Exhaustion
+// =============================================================================
+
+/// Test CPU time budget exhaustion.
+#[tokio::test]
+async fn test_cpu_time_budget_exhaustion() {
+    let budget = EpisodeBudget::builder().cpu_ms(30_000).build(); // 30 seconds
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Charge 25 seconds
+    let delta = BudgetDelta {
+        cpu_ms: 25_000,
+        tool_calls: 1,
+        ..Default::default()
+    };
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    // Charge 10 more seconds - should fail
+    let delta = BudgetDelta {
+        cpu_ms: 10_000,
+        tool_calls: 1,
+        ..Default::default()
+    };
+    let result = TestDaemon::charge_budget(&tracker, &delta);
+
+    assert!(matches!(
+        result,
+        Err(BudgetExhaustedError::CpuTime {
+            requested: 10_000,
+            remaining: 5_000
+        })
+    ));
+}
+
+/// Test CPU time is tracked separately from wall time.
+#[tokio::test]
+async fn test_cpu_time_separate_from_wall_time() {
+    let budget = EpisodeBudget::builder()
+        .wall_ms(100_000)
+        .cpu_ms(10_000)
+        .build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // CPU-intensive operation: 9s CPU in 20s wall time
+    let delta = BudgetDelta {
+        wall_ms: 20_000,
+        cpu_ms: 9_000,
+        tool_calls: 1,
+        ..Default::default()
+    };
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    // Wall time not exhausted, but CPU time nearly is
+    assert!(!tracker.is_wall_time_exhausted());
+    assert!(!tracker.is_cpu_time_exhausted());
+
+    // Another CPU-heavy operation
+    let delta = BudgetDelta {
+        wall_ms: 5_000,
+        cpu_ms: 2_000, // Exceeds CPU limit
+        tool_calls: 1,
+        ..Default::default()
+    };
+    let result = TestDaemon::charge_budget(&tracker, &delta);
+    assert!(matches!(result, Err(BudgetExhaustedError::CpuTime { .. })));
+}
+
+// =============================================================================
+// UT-BG-005: I/O Bytes Exhaustion
+// =============================================================================
+
+/// Test I/O bytes budget exhaustion.
+#[tokio::test]
+async fn test_io_bytes_budget_exhaustion() {
+    let budget = EpisodeBudget::builder().bytes_io(1_000_000).build(); // 1 MB
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Read/write 800 KB
+    let delta = BudgetDelta::single_call().with_bytes_io(800_000);
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    // Try to read/write 300 KB more - should fail
+    let delta = BudgetDelta::single_call().with_bytes_io(300_000);
+    let result = TestDaemon::charge_budget(&tracker, &delta);
+
+    assert!(matches!(
+        result,
+        Err(BudgetExhaustedError::BytesIo {
+            requested: 300_000,
+            remaining: 200_000
+        })
+    ));
+}
+
+/// Test I/O bytes with combined read/write operations.
+#[tokio::test]
+async fn test_io_bytes_combined_operations() {
+    let budget = EpisodeBudget::builder().bytes_io(100_000).build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Multiple I/O operations
+    for _ in 0..9 {
+        let delta = BudgetDelta::single_call().with_bytes_io(10_000);
+        TestDaemon::charge_budget(&tracker, &delta).unwrap();
+    }
+
+    // 10th operation with 15KB should fail
+    let delta = BudgetDelta::single_call().with_bytes_io(15_000);
+    let result = TestDaemon::charge_budget(&tracker, &delta);
+    assert!(matches!(result, Err(BudgetExhaustedError::BytesIo { .. })));
+}
+
+// =============================================================================
+// UT-BG-006: Evidence Bytes Exhaustion
+// =============================================================================
+
+/// Test evidence bytes budget exhaustion.
+#[tokio::test]
+async fn test_evidence_bytes_budget_exhaustion() {
+    let budget = EpisodeBudget::builder().evidence_bytes(100_000).build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Store 50 KB of evidence
+    tracker.charge_evidence(50_000).unwrap();
+
+    // Store 60 KB more - should fail
+    let result = tracker.charge_evidence(60_000);
+
+    assert!(matches!(
+        result,
+        Err(BudgetExhaustedError::EvidenceBytes {
+            requested: 60_000,
+            remaining: 50_000
+        })
+    ));
+}
+
+/// Test evidence bytes exact exhaustion.
+#[tokio::test]
+async fn test_evidence_bytes_exact_exhaustion() {
+    let budget = EpisodeBudget::builder().evidence_bytes(10_000).build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Exactly exhaust
+    tracker.charge_evidence(10_000).unwrap();
+
+    assert!(tracker.is_evidence_bytes_exhausted());
+
+    // Any more should fail
+    let result = tracker.charge_evidence(1);
+    assert!(matches!(
+        result,
+        Err(BudgetExhaustedError::EvidenceBytes { .. })
+    ));
+}
+
+// =============================================================================
+// UT-BG-007: Budget Exhausted Termination
+// =============================================================================
+
+/// Test budget exhausted stop signal.
+#[tokio::test]
+async fn test_budget_exhausted_stop_signal() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    let handle = daemon.start_episode(&episode_id).await.unwrap();
+
+    // Signal budget exhausted
+    daemon
+        .signal_episode(
+            &episode_id,
+            StopSignal::BudgetExhausted {
+                resource: "tokens".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(handle.should_stop());
+    let signal = handle.current_stop_signal();
+    assert!(matches!(
+        signal,
+        StopSignal::BudgetExhausted { ref resource } if resource == "tokens"
+    ));
+
+    // Verify termination class mapping
+    assert_eq!(
+        signal.termination_class(),
+        Some(TerminationClass::BudgetExhausted)
+    );
+}
+
+/// Test budget exhausted termination class.
+#[tokio::test]
+async fn test_budget_exhausted_termination_class() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+
+    daemon
+        .stop_episode(&episode_id, TerminationClass::BudgetExhausted)
+        .await
+        .unwrap();
+
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert!(matches!(
+        state,
+        apm2_daemon::episode::EpisodeState::Terminated {
+            termination_class: TerminationClass::BudgetExhausted,
+            ..
+        }
+    ));
+}
+
+/// Test budget exhausted event in lifecycle.
+#[tokio::test]
+async fn test_budget_exhausted_lifecycle() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+    daemon.drain_events().await; // Clear previous events
+
+    daemon
+        .stop_episode(&episode_id, TerminationClass::BudgetExhausted)
+        .await
+        .unwrap();
+
+    let events = daemon.drain_events().await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_type(), "episode.stopped");
+
+    // Verify the stopped event has BudgetExhausted
+    if let apm2_daemon::episode::EpisodeEvent::Stopped {
+        termination_class, ..
+    } = &events[0]
+    {
+        assert_eq!(*termination_class, TerminationClass::BudgetExhausted);
+    } else {
+        panic!("Expected Stopped event");
+    }
+}
+
+// =============================================================================
+// UT-BG-008: Concurrent Budget Charging
+// =============================================================================
+
+/// Test concurrent budget charging respects limits.
+#[tokio::test]
+async fn test_concurrent_budget_charging_respects_limits() {
+    use std::sync::Arc;
+
+    let budget = EpisodeBudget::builder().tool_calls(100).build();
+    let tracker = Arc::new(BudgetTracker::from_envelope(budget));
+
+    // Spawn 20 threads each trying to charge 10 tool calls
+    let mut handles = Vec::new();
+    for _ in 0..20 {
+        let tracker_clone = Arc::clone(&tracker);
+        let handle = tokio::spawn(async move {
+            let mut successes = 0;
+            for _ in 0..10 {
+                if tracker_clone.charge(&BudgetDelta::single_call()).is_ok() {
+                    successes += 1;
+                }
+            }
+            successes
+        });
+        handles.push(handle);
+    }
+
+    // Collect results
+    let total_successes: u32 = futures::future::join_all(handles)
+        .await
+        .into_iter()
+        .map(|r| r.unwrap())
+        .sum();
+
+    // Total successes should be exactly 100 (the limit)
+    assert_eq!(
+        total_successes, 100,
+        "Expected exactly 100 successful charges, got {total_successes}"
+    );
+
+    // Verify consumed equals limit
+    let consumed = tracker.consumed();
+    assert_eq!(consumed.tool_calls, 100);
+}
+
+/// Test concurrent token charging.
+#[tokio::test]
+async fn test_concurrent_token_charging() {
+    use std::sync::Arc;
+
+    let budget = EpisodeBudget::builder().tokens(10_000).build();
+    let tracker = Arc::new(BudgetTracker::from_envelope(budget));
+
+    // Spawn 10 threads each charging 100 tokens 10 times
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let tracker_clone = Arc::clone(&tracker);
+        let handle = tokio::spawn(async move {
+            for _ in 0..10 {
+                let _ = tracker_clone.charge(&BudgetDelta::single_call().with_tokens(100));
+            }
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all
+    futures::future::join_all(handles).await;
+
+    // Consumed should not exceed limit
+    let consumed = tracker.consumed();
+    assert!(
+        consumed.tokens <= 10_000,
+        "Consumed {} tokens but limit is 10_000",
+        consumed.tokens
+    );
+}
+
+// =============================================================================
+// Unlimited Budget Tests
+// =============================================================================
+
+/// Test unlimited budget allows large charges.
+#[tokio::test]
+async fn test_unlimited_budget() {
+    let tracker = BudgetTracker::unlimited();
+
+    // Very large charges should succeed
+    let delta = BudgetDelta::single_call()
+        .with_tokens(1_000_000_000)
+        .with_bytes_io(1_000_000_000);
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    assert!(!TestDaemon::is_budget_exhausted(&tracker));
+}
+
+/// Test unlimited budget remaining returns zero (not MAX).
+#[tokio::test]
+async fn test_unlimited_budget_remaining_is_zero() {
+    let tracker = BudgetTracker::unlimited();
+
+    let remaining = tracker.remaining();
+
+    // For unlimited, remaining is 0 (not u64::MAX)
+    assert_eq!(remaining.tokens(), 0);
+    assert_eq!(remaining.tool_calls(), 0);
+    assert_eq!(remaining.wall_ms(), 0);
+    assert!(remaining.is_unlimited());
+}
+
+// =============================================================================
+// Budget Reconciliation Tests
+// =============================================================================
+
+/// Test budget reconciliation refunds excess pre-charge.
+#[tokio::test]
+async fn test_budget_reconciliation_refund() {
+    let tracker = TestDaemon::create_test_budget_tracker();
+
+    // Pre-charge an estimate
+    let estimate = BudgetDelta::single_call()
+        .with_tokens(1000)
+        .with_bytes_io(5000);
+    TestDaemon::charge_budget(&tracker, &estimate).unwrap();
+
+    // Actual usage was less
+    let actual = BudgetDelta::single_call()
+        .with_tokens(600)
+        .with_bytes_io(3000);
+
+    // Reconcile should succeed
+    tracker.reconcile(&estimate, &actual).unwrap();
+
+    // Verify refund was applied
+    let consumed = TestDaemon::consumed_budget(&tracker);
+    assert_eq!(consumed.tokens, 600);
+    assert_eq!(consumed.bytes_io, 3000);
+}
+
+/// Test budget reconciliation fails when actual exceeds estimate.
+#[tokio::test]
+async fn test_budget_reconciliation_actual_exceeds_estimate() {
+    let tracker = TestDaemon::create_test_budget_tracker();
+
+    // Pre-charge an estimate
+    let estimate = BudgetDelta::single_call().with_tokens(500);
+    TestDaemon::charge_budget(&tracker, &estimate).unwrap();
+
+    // Actual usage exceeded estimate
+    let actual = BudgetDelta::single_call().with_tokens(700);
+
+    // Reconcile should fail
+    let result = tracker.reconcile(&estimate, &actual);
+    assert!(matches!(
+        result,
+        Err(BudgetExhaustedError::ActualExceededEstimate {
+            resource: "tokens",
+            ..
+        })
+    ));
+
+    // Budget should remain at the charged amount
+    let consumed = TestDaemon::consumed_budget(&tracker);
+    assert_eq!(consumed.tokens, 500);
+}
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+/// Test zero charge is allowed.
+#[tokio::test]
+async fn test_zero_charge_allowed() {
+    let tracker = TestDaemon::create_test_budget_tracker();
+
+    let delta = BudgetDelta::default();
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    let consumed = TestDaemon::consumed_budget(&tracker);
+    assert!(consumed.tokens == 0);
+    assert!(consumed.tool_calls == 0);
+}
+
+/// Test checking exhaustion status of individual resources.
+#[tokio::test]
+async fn test_individual_resource_exhaustion_status() {
+    let budget = EpisodeBudget::builder()
+        .tokens(100)
+        .tool_calls(5)
+        .wall_ms(1000)
+        .cpu_ms(500)
+        .bytes_io(10_000)
+        .evidence_bytes(5000)
+        .build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Exhaust tokens only
+    tracker
+        .charge(&BudgetDelta::default().with_tokens(100))
+        .unwrap();
+
+    assert!(tracker.is_tokens_exhausted());
+    assert!(!tracker.is_tool_calls_exhausted());
+    assert!(!tracker.is_wall_time_exhausted());
+    assert!(!tracker.is_cpu_time_exhausted());
+    assert!(!tracker.is_bytes_io_exhausted());
+    assert!(!tracker.is_evidence_bytes_exhausted());
+
+    // Overall is exhausted because tokens are
+    assert!(tracker.is_exhausted());
+}
+
+/// Test budget limits are immutable.
+#[tokio::test]
+async fn test_budget_limits_immutable() {
+    let budget = EpisodeBudget::builder().tokens(1000).tool_calls(50).build();
+    let tracker = TestDaemon::create_budget_tracker(budget);
+
+    // Charge some resources
+    let delta = BudgetDelta::single_call().with_tokens(500);
+    TestDaemon::charge_budget(&tracker, &delta).unwrap();
+
+    // Limits should remain unchanged
+    let limits = tracker.limits();
+    assert_eq!(limits.tokens(), 1000);
+    assert_eq!(limits.tool_calls(), 50);
+}
+
+/// Test `would_exceed` predicate on `BudgetDelta`.
+#[tokio::test]
+async fn test_budget_delta_would_exceed() {
+    let remaining = EpisodeBudget::builder().tokens(100).tool_calls(5).build();
+
+    let delta1 = BudgetDelta::single_call().with_tokens(50);
+    assert!(!delta1.would_exceed(&remaining));
+
+    let delta2 = BudgetDelta::single_call().with_tokens(150);
+    assert!(delta2.would_exceed(&remaining));
+
+    let delta3 = BudgetDelta {
+        tool_calls: 6,
+        ..Default::default()
+    };
+    assert!(delta3.would_exceed(&remaining));
+
+    // Unlimited budget
+    let unlimited = EpisodeBudget::unlimited();
+    let large_delta = BudgetDelta::single_call().with_tokens(1_000_000);
+    assert!(!large_delta.would_exceed(&unlimited));
+}

--- a/crates/apm2-daemon/tests/e2e_lifecycle.rs
+++ b/crates/apm2-daemon/tests/e2e_lifecycle.rs
@@ -1,0 +1,989 @@
+//! End-to-end episode lifecycle tests.
+//!
+//! This module tests the complete episode lifecycle including:
+//! - Create -> Start -> Stop cycle
+//! - Concurrent episode management
+//! - Episode status queries
+//! - Invalid transition rejection
+//! - Termination enforcement
+//! - Quarantine on failure
+//! - Event emission verification
+//!
+//! # Contract References
+//!
+//! - TCK-00175: E2E lifecycle and budget tests
+//! - REQ-EPISODE-001: Episode envelope requirements
+//! - REQ-DAEMON-001: Daemon requirements
+//! - AD-EPISODE-002: Episode state machine
+//!
+//! # Test Coverage
+//!
+//! | Test ID        | Description                          |
+//! |----------------|--------------------------------------|
+//! | E2E-00175-01   | Lifecycle E2E                        |
+//! | UT-LF-001      | Happy path lifecycle                 |
+//! | UT-LF-002      | Concurrent episodes                  |
+//! | UT-LF-003      | Status queries                       |
+//! | UT-LF-004      | Invalid transitions                  |
+//! | UT-LF-005      | Termination enforcement              |
+//! | UT-LF-006      | Quarantine on crash                  |
+//! | UT-LF-007      | Event emission                       |
+
+mod common;
+
+use apm2_daemon::episode::{
+    EpisodeError, EpisodeEvent, EpisodeRuntimeConfig, EpisodeState, QuarantineReason, StopSignal,
+    TerminationClass,
+};
+use common::TestDaemon;
+
+// =============================================================================
+// UT-LF-001: Happy Path Lifecycle Tests
+// =============================================================================
+
+/// Test the basic create -> start -> stop lifecycle.
+#[tokio::test]
+async fn test_episode_lifecycle_happy_path() {
+    let daemon = TestDaemon::start();
+
+    // Create episode
+    let episode_id = daemon.create_episode().await.unwrap();
+
+    // Verify created state
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert!(matches!(state, EpisodeState::Created { .. }));
+    assert!(!state.is_terminal());
+    assert!(state.is_active());
+
+    // Start episode
+    let handle = daemon.start_episode(&episode_id).await.unwrap();
+    assert!(!handle.should_stop());
+    assert_eq!(handle.episode_id().as_str(), episode_id.as_str());
+
+    // Verify running state
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert!(matches!(state, EpisodeState::Running { .. }));
+    assert!(state.is_running());
+
+    // Stop episode
+    daemon
+        .stop_episode(&episode_id, TerminationClass::Success)
+        .await
+        .unwrap();
+
+    // Verify terminated state
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert!(matches!(
+        state,
+        EpisodeState::Terminated {
+            termination_class: TerminationClass::Success,
+            ..
+        }
+    ));
+    assert!(state.is_terminal());
+}
+
+/// Test lifecycle with failure termination.
+#[tokio::test]
+async fn test_episode_lifecycle_failure() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+
+    daemon
+        .stop_episode(&episode_id, TerminationClass::Failure)
+        .await
+        .unwrap();
+
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert!(matches!(
+        state,
+        EpisodeState::Terminated {
+            termination_class: TerminationClass::Failure,
+            ..
+        }
+    ));
+}
+
+/// Test lifecycle with cancellation.
+#[tokio::test]
+async fn test_episode_lifecycle_cancelled() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+
+    daemon
+        .stop_episode(&episode_id, TerminationClass::Cancelled)
+        .await
+        .unwrap();
+
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert!(matches!(
+        state,
+        EpisodeState::Terminated {
+            termination_class: TerminationClass::Cancelled,
+            ..
+        }
+    ));
+}
+
+/// Test lifecycle with timeout.
+#[tokio::test]
+async fn test_episode_lifecycle_timeout() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+
+    daemon
+        .stop_episode(&episode_id, TerminationClass::Timeout)
+        .await
+        .unwrap();
+
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert!(matches!(
+        state,
+        EpisodeState::Terminated {
+            termination_class: TerminationClass::Timeout,
+            ..
+        }
+    ));
+}
+
+// =============================================================================
+// UT-LF-002: Concurrent Episode Tests
+// =============================================================================
+
+/// Test concurrent episode creation.
+#[tokio::test]
+async fn test_concurrent_episode_creation() {
+    let daemon = TestDaemon::start();
+
+    // Create multiple episodes
+    let ep1 = daemon.create_episode().await.unwrap();
+    let ep2 = daemon.create_episode().await.unwrap();
+    let ep3 = daemon.create_episode().await.unwrap();
+
+    // All should be created
+    assert_eq!(daemon.active_count().await, 3);
+
+    // Verify each is in Created state
+    for ep_id in [&ep1, &ep2, &ep3] {
+        let state = daemon.observe_episode(ep_id).await.unwrap();
+        assert!(matches!(state, EpisodeState::Created { .. }));
+    }
+
+    // Start all episodes
+    daemon.start_episode(&ep1).await.unwrap();
+    daemon.start_episode(&ep2).await.unwrap();
+    daemon.start_episode(&ep3).await.unwrap();
+
+    // All should be running
+    for ep_id in [&ep1, &ep2, &ep3] {
+        let state = daemon.observe_episode(ep_id).await.unwrap();
+        assert!(matches!(state, EpisodeState::Running { .. }));
+    }
+
+    // Stop all episodes
+    daemon
+        .stop_episode(&ep1, TerminationClass::Success)
+        .await
+        .unwrap();
+    daemon
+        .stop_episode(&ep2, TerminationClass::Failure)
+        .await
+        .unwrap();
+    daemon
+        .stop_episode(&ep3, TerminationClass::Cancelled)
+        .await
+        .unwrap();
+
+    // All should be terminal
+    assert_eq!(daemon.active_count().await, 0);
+    assert_eq!(daemon.total_count().await, 3);
+}
+
+/// Test episode limit enforcement.
+#[tokio::test]
+async fn test_episode_limit_enforcement() {
+    let daemon = TestDaemon::with_max_episodes(3);
+
+    // Create up to limit
+    let ep1 = daemon.create_episode().await.unwrap();
+    let ep2 = daemon.create_episode().await.unwrap();
+    let ep3 = daemon.create_episode().await.unwrap();
+
+    assert_eq!(daemon.total_count().await, 3);
+
+    // Fourth creation should fail
+    let result = daemon.create_episode().await;
+    assert!(matches!(
+        result,
+        Err(EpisodeError::LimitReached { limit: 3 })
+    ));
+
+    // Stop one episode
+    daemon.start_episode(&ep1).await.unwrap();
+    daemon
+        .stop_episode(&ep1, TerminationClass::Success)
+        .await
+        .unwrap();
+
+    // Still at limit (terminated episode still tracked)
+    let result = daemon.create_episode().await;
+    assert!(matches!(result, Err(EpisodeError::LimitReached { .. })));
+
+    // Cleanup terminal episodes
+    let cleaned = daemon.cleanup_terminal().await;
+    assert_eq!(cleaned, 1);
+
+    // Now we can create again
+    let _ep4 = daemon.create_episode().await.unwrap();
+    assert_eq!(daemon.total_count().await, 3);
+
+    // Cleanup
+    drop(ep2);
+    drop(ep3);
+}
+
+/// Test concurrent lifecycle operations with async spawn.
+#[tokio::test]
+async fn test_concurrent_lifecycle_operations() {
+    use std::sync::Arc;
+
+    let daemon = Arc::new(TestDaemon::start());
+
+    // Create multiple episodes concurrently
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let d = Arc::clone(&daemon);
+        handles.push(tokio::spawn(async move {
+            let ep_id = d.create_episode().await.unwrap();
+            let _handle = d.start_episode(&ep_id).await.unwrap();
+            d.stop_episode(&ep_id, TerminationClass::Success)
+                .await
+                .unwrap();
+            ep_id
+        }));
+    }
+
+    // Wait for all to complete
+    let mut episode_ids = std::collections::HashSet::new();
+    for handle in handles {
+        let ep_id = handle.await.unwrap();
+        episode_ids.insert(ep_id.as_str().to_string());
+    }
+
+    // All 10 should have unique IDs
+    assert_eq!(episode_ids.len(), 10);
+
+    // All should be terminal
+    assert_eq!(daemon.active_count().await, 0);
+    assert_eq!(daemon.total_count().await, 10);
+}
+
+// =============================================================================
+// UT-LF-003: Status Query Tests
+// =============================================================================
+
+/// Test episode status transitions.
+#[tokio::test]
+async fn test_episode_status_transitions() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+
+    // Created
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert_eq!(state.state_name(), "Created");
+    assert!(!state.is_running());
+    assert!(!state.is_terminal());
+    assert!(state.is_active());
+
+    // Running
+    daemon.start_episode(&episode_id).await.unwrap();
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert_eq!(state.state_name(), "Running");
+    assert!(state.is_running());
+    assert!(!state.is_terminal());
+    assert!(state.is_active());
+
+    // Terminated
+    daemon
+        .stop_episode(&episode_id, TerminationClass::Success)
+        .await
+        .unwrap();
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert_eq!(state.state_name(), "Terminated");
+    assert!(!state.is_running());
+    assert!(state.is_terminal());
+    assert!(!state.is_active());
+}
+
+/// Test session handle properties.
+#[tokio::test]
+async fn test_session_handle_properties() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    let handle = daemon
+        .start_episode_with_lease(&episode_id, "test-lease-123")
+        .await
+        .unwrap();
+
+    // Verify handle properties
+    assert_eq!(handle.episode_id().as_str(), episode_id.as_str());
+    assert_eq!(handle.lease_id(), "test-lease-123");
+    assert!(!handle.session_id().is_empty());
+    assert!(!handle.should_stop());
+}
+
+/// Test querying non-existent episode.
+#[tokio::test]
+async fn test_query_nonexistent_episode() {
+    let daemon = TestDaemon::start();
+
+    let fake_id = apm2_daemon::episode::EpisodeId::new("ep-nonexistent").unwrap();
+    let result = daemon.observe_episode(&fake_id).await;
+
+    assert!(matches!(result, Err(EpisodeError::NotFound { .. })));
+}
+
+// =============================================================================
+// UT-LF-004: Invalid Transition Tests
+// =============================================================================
+
+/// Test starting an already running episode.
+#[tokio::test]
+async fn test_invalid_start_already_running() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+
+    // Try to start again
+    let result = daemon.start_episode(&episode_id).await;
+    assert!(matches!(
+        result,
+        Err(EpisodeError::InvalidTransition { .. })
+    ));
+}
+
+/// Test starting a terminated episode.
+#[tokio::test]
+async fn test_invalid_start_terminated() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+    daemon
+        .stop_episode(&episode_id, TerminationClass::Success)
+        .await
+        .unwrap();
+
+    // Try to start terminated episode
+    let result = daemon.start_episode(&episode_id).await;
+    assert!(matches!(
+        result,
+        Err(EpisodeError::InvalidTransition { .. })
+    ));
+}
+
+/// Test stopping a non-running episode.
+#[tokio::test]
+async fn test_invalid_stop_not_running() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+
+    // Try to stop without starting
+    let result = daemon
+        .stop_episode(&episode_id, TerminationClass::Success)
+        .await;
+    assert!(matches!(
+        result,
+        Err(EpisodeError::InvalidTransition { .. })
+    ));
+}
+
+/// Test double stop.
+#[tokio::test]
+async fn test_invalid_double_stop() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+    daemon
+        .stop_episode(&episode_id, TerminationClass::Success)
+        .await
+        .unwrap();
+
+    // Try to stop again
+    let result = daemon
+        .stop_episode(&episode_id, TerminationClass::Cancelled)
+        .await;
+    assert!(matches!(
+        result,
+        Err(EpisodeError::InvalidTransition { .. })
+    ));
+}
+
+/// Test quarantining a created (not running) episode.
+#[tokio::test]
+async fn test_invalid_quarantine_not_running() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+
+    // Try to quarantine without starting
+    let result = daemon
+        .quarantine_episode(&episode_id, QuarantineReason::crash("test"))
+        .await;
+    assert!(matches!(
+        result,
+        Err(EpisodeError::InvalidTransition { .. })
+    ));
+}
+
+/// Test invalid lease ID (empty).
+#[tokio::test]
+async fn test_invalid_empty_lease_id() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+
+    // Try to start with empty lease
+    let result = daemon.start_episode_with_lease(&episode_id, "").await;
+    assert!(matches!(result, Err(EpisodeError::InvalidLease { .. })));
+}
+
+// =============================================================================
+// UT-LF-005: Termination Enforcement Tests
+// =============================================================================
+
+/// Test graceful stop signal.
+#[tokio::test]
+async fn test_graceful_stop_signal() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    let handle = daemon.start_episode(&episode_id).await.unwrap();
+
+    // Signal graceful stop
+    daemon
+        .signal_episode(
+            &episode_id,
+            StopSignal::Graceful {
+                reason: "test graceful stop".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Handle should indicate stop
+    assert!(handle.should_stop());
+    assert!(matches!(
+        handle.current_stop_signal(),
+        StopSignal::Graceful { reason } if reason == "test graceful stop"
+    ));
+}
+
+/// Test immediate stop signal.
+#[tokio::test]
+async fn test_immediate_stop_signal() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    let handle = daemon.start_episode(&episode_id).await.unwrap();
+
+    // Signal immediate stop
+    daemon
+        .signal_episode(
+            &episode_id,
+            StopSignal::Immediate {
+                reason: "test immediate stop".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(handle.should_stop());
+    assert!(matches!(
+        handle.current_stop_signal(),
+        StopSignal::Immediate { reason } if reason == "test immediate stop"
+    ));
+}
+
+/// Test external signal (SIGTERM simulation).
+#[tokio::test]
+async fn test_external_sigterm_signal() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    let handle = daemon.start_episode(&episode_id).await.unwrap();
+
+    // Signal SIGTERM
+    daemon
+        .signal_episode(
+            &episode_id,
+            StopSignal::External {
+                signal: "SIGTERM".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(handle.should_stop());
+    let signal = handle.current_stop_signal();
+    assert!(matches!(
+        signal,
+        StopSignal::External { ref signal } if signal == "SIGTERM"
+    ));
+
+    // Verify termination class mapping
+    assert_eq!(
+        signal.termination_class(),
+        Some(TerminationClass::Cancelled)
+    );
+}
+
+/// Test external signal (SIGKILL simulation).
+#[tokio::test]
+async fn test_external_sigkill_signal() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    let handle = daemon.start_episode(&episode_id).await.unwrap();
+
+    // Signal SIGKILL
+    daemon
+        .signal_episode(
+            &episode_id,
+            StopSignal::External {
+                signal: "SIGKILL".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(handle.should_stop());
+    let signal = handle.current_stop_signal();
+
+    // Verify SIGKILL maps to Killed termination
+    assert_eq!(signal.termination_class(), Some(TerminationClass::Killed));
+}
+
+/// Test signaling a non-running episode fails.
+#[tokio::test]
+async fn test_signal_nonrunning_episode_fails() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+
+    // Try to signal before starting
+    let result = daemon
+        .signal_episode(
+            &episode_id,
+            StopSignal::Graceful {
+                reason: "test".to_string(),
+            },
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(EpisodeError::InvalidTransition { .. })
+    ));
+}
+
+/// Test killed termination class.
+#[tokio::test]
+async fn test_killed_termination() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+
+    daemon
+        .stop_episode(&episode_id, TerminationClass::Killed)
+        .await
+        .unwrap();
+
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert!(matches!(
+        state,
+        EpisodeState::Terminated {
+            termination_class: TerminationClass::Killed,
+            ..
+        }
+    ));
+}
+
+// =============================================================================
+// UT-LF-006: Quarantine Tests
+// =============================================================================
+
+/// Test quarantine on crash.
+#[tokio::test]
+async fn test_quarantine_on_crash() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+
+    let reason = QuarantineReason::crash("simulated crash");
+    daemon
+        .quarantine_episode(&episode_id, reason.clone())
+        .await
+        .unwrap();
+
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert!(matches!(state, EpisodeState::Quarantined { .. }));
+    assert!(state.is_terminal());
+
+    if let EpisodeState::Quarantined { reason: r, .. } = state {
+        assert_eq!(r.code, "CRASH");
+        assert!(r.description.contains("simulated crash"));
+    }
+}
+
+/// Test quarantine on policy violation.
+#[tokio::test]
+async fn test_quarantine_on_policy_violation() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+
+    let reason = QuarantineReason::policy_violation("DENY_EXECUTE");
+    daemon
+        .quarantine_episode(&episode_id, reason)
+        .await
+        .unwrap();
+
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert!(matches!(state, EpisodeState::Quarantined { .. }));
+
+    if let EpisodeState::Quarantined { reason: r, .. } = state {
+        assert_eq!(r.code, "POLICY_VIOLATION");
+        assert!(r.description.contains("DENY_EXECUTE"));
+    }
+}
+
+/// Test quarantine on security incident.
+#[tokio::test]
+async fn test_quarantine_on_security_incident() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+
+    let reason = QuarantineReason::security_incident("unauthorized access attempt");
+    daemon
+        .quarantine_episode(&episode_id, reason)
+        .await
+        .unwrap();
+
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    assert!(matches!(state, EpisodeState::Quarantined { .. }));
+
+    if let EpisodeState::Quarantined { reason: r, .. } = state {
+        assert_eq!(r.code, "SECURITY_INCIDENT");
+    }
+}
+
+/// Test quarantine with evidence reference.
+#[tokio::test]
+async fn test_quarantine_with_evidence() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+
+    let evidence_hash = [0xABu8; 32];
+    let reason = QuarantineReason::crash("crash with evidence").with_evidence(evidence_hash);
+    daemon
+        .quarantine_episode(&episode_id, reason)
+        .await
+        .unwrap();
+
+    let state = daemon.observe_episode(&episode_id).await.unwrap();
+    if let EpisodeState::Quarantined { reason: r, .. } = state {
+        assert_eq!(r.evidence_refs.len(), 1);
+        assert_eq!(r.evidence_refs[0], evidence_hash);
+    }
+}
+
+/// Test quarantine signal through handle.
+#[tokio::test]
+async fn test_quarantine_signal() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    let handle = daemon.start_episode(&episode_id).await.unwrap();
+
+    // Signal quarantine
+    daemon
+        .signal_episode(
+            &episode_id,
+            StopSignal::Quarantine {
+                reason: "test quarantine signal".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(handle.should_stop());
+    let signal = handle.current_stop_signal();
+    assert!(signal.requires_quarantine());
+    assert!(
+        matches!(signal, StopSignal::Quarantine { reason } if reason == "test quarantine signal")
+    );
+}
+
+/// Test no further transitions from quarantined state.
+#[tokio::test]
+async fn test_no_transitions_from_quarantined() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+    daemon
+        .quarantine_episode(&episode_id, QuarantineReason::crash("test"))
+        .await
+        .unwrap();
+
+    // Cannot start
+    let result = daemon.start_episode(&episode_id).await;
+    assert!(matches!(
+        result,
+        Err(EpisodeError::InvalidTransition { .. })
+    ));
+
+    // Cannot stop
+    let result = daemon
+        .stop_episode(&episode_id, TerminationClass::Success)
+        .await;
+    assert!(matches!(
+        result,
+        Err(EpisodeError::InvalidTransition { .. })
+    ));
+
+    // Cannot quarantine again
+    let result = daemon
+        .quarantine_episode(&episode_id, QuarantineReason::crash("again"))
+        .await;
+    assert!(matches!(
+        result,
+        Err(EpisodeError::InvalidTransition { .. })
+    ));
+}
+
+// =============================================================================
+// UT-LF-007: Event Emission Tests
+// =============================================================================
+
+/// Test episode.created event.
+#[tokio::test]
+async fn test_event_episode_created() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    let events = daemon.drain_events().await;
+
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0], EpisodeEvent::Created { .. }));
+    assert_eq!(events[0].event_type(), "episode.created");
+    assert_eq!(events[0].episode_id().as_str(), episode_id.as_str());
+}
+
+/// Test episode.started event.
+#[tokio::test]
+async fn test_event_episode_started() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.drain_events().await; // Clear create event
+
+    daemon.start_episode(&episode_id).await.unwrap();
+    let events = daemon.drain_events().await;
+
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0], EpisodeEvent::Started { .. }));
+    assert_eq!(events[0].event_type(), "episode.started");
+}
+
+/// Test episode.stopped event.
+#[tokio::test]
+async fn test_event_episode_stopped() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+    daemon.drain_events().await; // Clear previous events
+
+    daemon
+        .stop_episode(&episode_id, TerminationClass::Success)
+        .await
+        .unwrap();
+    let events = daemon.drain_events().await;
+
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0], EpisodeEvent::Stopped { .. }));
+    assert_eq!(events[0].event_type(), "episode.stopped");
+}
+
+/// Test episode.quarantined event.
+#[tokio::test]
+async fn test_event_episode_quarantined() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+    daemon.drain_events().await; // Clear previous events
+
+    daemon
+        .quarantine_episode(&episode_id, QuarantineReason::crash("test"))
+        .await
+        .unwrap();
+    let events = daemon.drain_events().await;
+
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0], EpisodeEvent::Quarantined { .. }));
+    assert_eq!(events[0].event_type(), "episode.quarantined");
+}
+
+/// Test full lifecycle event sequence.
+#[tokio::test]
+async fn test_full_lifecycle_event_sequence() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+    daemon
+        .stop_episode(&episode_id, TerminationClass::Success)
+        .await
+        .unwrap();
+
+    let events = daemon.drain_events().await;
+
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].event_type(), "episode.created");
+    assert_eq!(events[1].event_type(), "episode.started");
+    assert_eq!(events[2].event_type(), "episode.stopped");
+
+    // All events should reference the same episode
+    for event in &events {
+        assert_eq!(event.episode_id().as_str(), episode_id.as_str());
+    }
+}
+
+/// Test event emission can be disabled.
+#[tokio::test]
+async fn test_event_emission_disabled() {
+    let config = EpisodeRuntimeConfig::default()
+        .with_max_concurrent_episodes(100)
+        .with_emit_events(false);
+    let daemon = TestDaemon::with_config(config);
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    daemon.start_episode(&episode_id).await.unwrap();
+    daemon
+        .stop_episode(&episode_id, TerminationClass::Success)
+        .await
+        .unwrap();
+
+    // No events should be emitted
+    let events = daemon.drain_events().await;
+    assert!(events.is_empty());
+}
+
+// =============================================================================
+// Additional Edge Cases
+// =============================================================================
+
+/// Test cleanup of terminal episodes.
+#[tokio::test]
+async fn test_cleanup_terminal_episodes() {
+    let daemon = TestDaemon::start();
+
+    // Create and terminate some episodes
+    let ep1 = daemon.create_episode().await.unwrap();
+    let ep2 = daemon.create_episode().await.unwrap();
+    let ep3 = daemon.create_episode().await.unwrap();
+
+    daemon.start_episode(&ep1).await.unwrap();
+    daemon
+        .stop_episode(&ep1, TerminationClass::Success)
+        .await
+        .unwrap();
+
+    daemon.start_episode(&ep2).await.unwrap();
+    daemon
+        .quarantine_episode(&ep2, QuarantineReason::crash("test"))
+        .await
+        .unwrap();
+
+    // ep3 is still in Created state
+    assert_eq!(daemon.active_count().await, 1);
+    assert_eq!(daemon.total_count().await, 3);
+
+    // Cleanup terminal
+    let cleaned = daemon.cleanup_terminal().await;
+    assert_eq!(cleaned, 2);
+
+    // Only active episode remains
+    assert_eq!(daemon.total_count().await, 1);
+    assert_eq!(daemon.active_count().await, 1);
+
+    // ep3 should still be observable
+    let state = daemon.observe_episode(&ep3).await.unwrap();
+    assert!(matches!(state, EpisodeState::Created { .. }));
+}
+
+/// Test session handle cloning shares channel.
+#[tokio::test]
+async fn test_session_handle_clone_shares_channel() {
+    let daemon = TestDaemon::start();
+
+    let episode_id = daemon.create_episode().await.unwrap();
+    let handle1 = daemon.start_episode(&episode_id).await.unwrap();
+    let handle2 = handle1.clone();
+
+    // Signal through one handle
+    handle1.signal_stop(StopSignal::Graceful {
+        reason: "clone test".to_string(),
+    });
+
+    // Both should see the signal
+    assert!(handle1.should_stop());
+    assert!(handle2.should_stop());
+}
+
+/// Test deterministic timestamp advancement.
+#[tokio::test]
+async fn test_deterministic_timestamps() {
+    let daemon = TestDaemon::start();
+
+    let ep_id = daemon.create_episode().await.unwrap();
+    let handle = daemon.start_episode(&ep_id).await.unwrap();
+
+    // Initially elapsed time is 0 (current timestamp equals start timestamp)
+    let initial_elapsed = handle.elapsed_ns(daemon.current_timestamp_ns());
+    assert_eq!(initial_elapsed, 0);
+
+    // Advance time by 100ms
+    daemon.advance_time_ms(100);
+
+    // Verify elapsed time is now 100ms
+    let elapsed = handle.elapsed_ns(daemon.current_timestamp_ns());
+    assert_eq!(elapsed, 100 * 1_000_000);
+
+    // Advance time by another 500ms
+    daemon.advance_time_ms(500);
+
+    let new_elapsed = handle.elapsed_ns(daemon.current_timestamp_ns());
+    assert_eq!(new_elapsed, 600 * 1_000_000);
+    assert_eq!(new_elapsed - elapsed, 500 * 1_000_000);
+}


### PR DESCRIPTION
## Summary

Implements comprehensive end-to-end tests for episode lifecycle management and budget enforcement in apm2-daemon, completing ticket TCK-00175 from RFC-0013.

- Add test utilities module (`TestDaemon`) with isolated test environments and deterministic timestamps (HARD-TIME compliance)
- Add 42 E2E lifecycle tests covering state machine transitions, concurrent episodes, quarantine, and event emission
- Add 31 E2E budget tests covering all resource types, concurrent charging, reconciliation, and stop signal propagation

## Test Coverage

| Category | Tests | Coverage |
|----------|-------|----------|
| Lifecycle happy path | 4 | create/start/stop with all termination classes |
| Concurrent episodes | 3 | limit enforcement, cleanup, parallel operations |
| Invalid transitions | 6 | double start/stop, terminal state blocking |
| Termination signals | 6 | graceful, immediate, SIGTERM, SIGKILL |
| Quarantine | 6 | crash, policy violation, security incident |
| Event emission | 5 | all lifecycle events verified |
| Token exhaustion | 3 | exact, incremental, limit check |
| Tool calls exhaustion | 2 | single, batch |
| Time exhaustion | 4 | wall time, CPU time (separate tracking) |
| I/O exhaustion | 3 | bytes_io, evidence_bytes |
| Budget termination | 3 | stop signal, termination class, events |
| Concurrent charging | 2 | race condition safety |
| Budget reconciliation | 2 | refund, overflow protection |
| Unlimited budget | 2 | no false exhaustion |

## Test plan

- [x] All 73 tests pass with `cargo test -p apm2-daemon --test e2e_lifecycle --test e2e_budget`
- [x] Clippy passes with `-D warnings`
- [x] Pre-commit hooks pass

## Contract References

- TCK-00175: E2E lifecycle and budget tests
- REQ-EPISODE-001: Episode envelope requirements
- AD-EPISODE-002: Episode state machine
- AD-LAYER-001: EpisodeRuntime as plant controller
- CTR-2504: Defensive time handling

Generated with [Claude Code](https://claude.com/claude-code)