### PR TITLE
feat(TCK-00194): integrate schema validation into append path

### DIFF
--- a/crates/apm2-core/src/ledger/mod.rs
+++ b/crates/apm2-core/src/ledger/mod.rs
@@ -68,7 +68,7 @@ pub use backend::{BoxFuture, HashFn, LedgerBackend, VerifyFn};
 pub use bft_backend::{
     AppendResult, BftLedgerBackend, BftLedgerError, ConsensusIndex, ConsensusMetadata,
     DEFAULT_FINALIZATION_TIMEOUT_MS, EventMetadata, HlcTimestamp, MAX_PENDING_EVENTS,
-    MergeOperator, OrderingGuarantee,
+    MergeOperator, NoOpSchemaRegistry, OrderingGuarantee,
 };
 pub use storage::{
     ArtifactRef, CURRENT_RECORD_VERSION, EventRecord, Ledger, LedgerError, LedgerStats,


### PR DESCRIPTION
## Summary

Implements ticket TCK-00194 as part of the xtask development automation.

## Ticket

See `documents/work/tickets/TCK-00194.yaml` for requirements.

## Test Plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test -p xtask` passes
- [ ] Manual testing of the new command
