### PR TITLE
feat(TCK-00200): cross-node capability verification integration

### DIFF
--- a/crates/apm2-core/src/lease/capability.rs
+++ b/crates/apm2-core/src/lease/capability.rs
@@ -1163,6 +1163,7 @@ impl CapabilityProof {
             if capability.is_expired_at(current_time) {
                 return Err(LeaseError::LeaseExpired {
                     lease_id: entry.capability_id.clone(),
+                    expired_at: capability.expires_at,
                 });
             }
 

--- a/crates/apm2-core/src/lease/error.rs
+++ b/crates/apm2-core/src/lease/error.rs
@@ -32,10 +32,12 @@ pub enum LeaseError {
     },
 
     /// The lease has expired.
-    #[error("lease {lease_id} has expired")]
+    #[error("lease {lease_id} has expired at {expired_at}")]
     LeaseExpired {
         /// The lease ID.
         lease_id: String,
+        /// When the lease expired (Unix nanos).
+        expired_at: u64,
     },
 
     /// The lease has been revoked.


### PR DESCRIPTION
## Summary

Implements ticket TCK-00200 as part of the xtask development automation.

## Ticket

See `documents/work/tickets/TCK-00200.yaml` for requirements.

## Test Plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test -p xtask` passes
- [ ] Manual testing of the new command
