### PR TITLE
feat(TCK-00204): fac: leaserevoked event type and enforcement

### DIFF
--- a/crates/apm2-core/src/events/apm2.kernel.v1.rs
+++ b/crates/apm2-core/src/events/apm2.kernel.v1.rs
@@ -356,7 +356,7 @@ pub struct ToolExecuted {
 #[derive(Eq, Hash)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeaseEvent {
-    #[prost(oneof = "lease_event::Event", tags = "1, 2, 3, 4, 5, 6")]
+    #[prost(oneof = "lease_event::Event", tags = "1, 2, 3, 4, 5, 6, 7")]
     pub event: ::core::option::Option<lease_event::Event>,
 }
 /// Nested message and enum types in `LeaseEvent`.
@@ -376,6 +376,8 @@ pub mod lease_event {
         Conflict(super::LeaseConflict),
         #[prost(message, tag = "6")]
         GateLeaseIssued(super::GateLeaseIssued),
+        #[prost(message, tag = "7")]
+        LeaseRevoked(super::LeaseRevoked),
     }
 }
 /// GateLease issued for Forge Admission Cycle execution.
@@ -490,6 +492,30 @@ pub struct LeaseConflict {
     /// CANONICAL_ROOT, ADJUDICATION_REQUIRED
     #[prost(string, tag = "3")]
     pub resolution: ::prost::alloc::string::String,
+}
+/// Immediate revocation of a lease before natural expiration.
+/// Critical for incident response when a key is compromised or executor misbehaves.
+#[derive(Eq, Hash)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LeaseRevoked {
+    /// ID of the lease being revoked
+    #[prost(string, tag = "1")]
+    pub lease_id: ::prost::alloc::string::String,
+    /// Actor who revoked the lease (must be issuer or authority)
+    #[prost(string, tag = "2")]
+    pub revoked_by: ::prost::alloc::string::String,
+    /// HTF tick at which the revocation takes effect
+    #[prost(uint64, tag = "3")]
+    pub revoked_at: u64,
+    /// Reason for revocation: KEY_COMPROMISE, POLICY_VIOLATION, MISBEHAVIOR, VOLUNTARY
+    #[prost(string, tag = "4")]
+    pub reason: ::prost::alloc::string::String,
+    /// Ed25519 signature over canonical bytes with LEASE_REVOKED: prefix
+    #[prost(bytes = "vec", tag = "5")]
+    pub issuer_signature: ::prost::alloc::vec::Vec<u8>,
+    /// HTF time envelope reference for temporal authority
+    #[prost(string, tag = "6")]
+    pub time_envelope_ref: ::prost::alloc::string::String,
 }
 /// ============================================================
 /// POLICY EVENTS

--- a/crates/apm2-core/src/fac/mod.rs
+++ b/crates/apm2-core/src/fac/mod.rs
@@ -57,5 +57,6 @@ pub use domain_separator::{
 // Re-export lease types
 pub use lease::{
     AatLeaseExtension, AatLeaseExtensionProto, GateLease, GateLeaseBuilder, GateLeaseProto,
-    GateLeaseScope, LeaseError,
+    GateLeaseScope, LeaseError, LeaseRevoked, LeaseRevokedBuilder, LeaseRevokedProto,
+    RevocationReason, is_lease_revoked,
 };

--- a/crates/apm2-core/src/lease/reducer.rs
+++ b/crates/apm2-core/src/lease/reducer.rs
@@ -519,6 +519,12 @@ impl Reducer for LeaseReducer {
                 // but is processed separately in the Forge Admission Cycle.
                 Ok(())
             },
+            Some(lease_event::Event::LeaseRevoked(_)) => {
+                // Lease revocations are handled by the FAC module, not this reducer.
+                // This event type is included in LeaseEvent for schema compatibility
+                // but is processed separately in the Forge Admission Cycle.
+                Ok(())
+            },
             None => Ok(()),
         }
     }

--- a/proto/kernel_events.proto
+++ b/proto/kernel_events.proto
@@ -224,6 +224,7 @@ message LeaseEvent {
     LeaseExpired expired = 4;
     LeaseConflict conflict = 5;
     GateLeaseIssued gate_lease_issued = 6;
+    LeaseRevoked lease_revoked = 7;
   }
 }
 
@@ -297,6 +298,23 @@ message LeaseConflict {
   string work_id = 1;
   repeated string conflicting_lease_ids = 2;
   string resolution = 3;  // CANONICAL_ROOT, ADJUDICATION_REQUIRED
+}
+
+// Immediate revocation of a lease before natural expiration.
+// Critical for incident response when a key is compromised or executor misbehaves.
+message LeaseRevoked {
+  // ID of the lease being revoked
+  string lease_id = 1;
+  // Actor who revoked the lease (must be issuer or authority)
+  string revoked_by = 2;
+  // HTF tick at which the revocation takes effect
+  uint64 revoked_at = 3;
+  // Reason for revocation: KEY_COMPROMISE, POLICY_VIOLATION, MISBEHAVIOR, VOLUNTARY
+  string reason = 4;
+  // Ed25519 signature over canonical bytes with LEASE_REVOKED: prefix
+  bytes issuer_signature = 5;
+  // HTF time envelope reference for temporal authority
+  string time_envelope_ref = 6;
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

Implements ticket TCK-00204 as part of the xtask development automation.

## Ticket

See `documents/work/tickets/TCK-00204.yaml` for requirements.

## Test Plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test -p xtask` passes
- [ ] Manual testing of the new command
