### PR TITLE
feat(TCK-00278): 50/50 model distribution for ai reviews

### DIFF
--- a/documents/work/tickets/TCK-00278.yaml
+++ b/documents/work/tickets/TCK-00278.yaml
@@ -1,0 +1,20 @@
+ticket_meta:
+  ticket:
+    id: "TCK-00278"
+    title: "50/50 Model Distribution for AI Reviews"
+    status: "IN_PROGRESS"
+    created: "2026-01-30"
+    rfc_id: null
+    parent_ticket: null
+    description: |
+      Distribute AI review model usage evenly between gemini-3-pro and
+      gemini-3-flash to balance quota consumption. Adds select_review_model()
+      helper that uses nanosecond-based selection for 50/50 distribution.
+    acceptance_criteria:
+      - "Add select_review_model() function in reviewer_state.rs"
+      - "Update push.rs to use select_review_model() (2 places)"
+      - "Update review.rs to use select_review_model() (1 place)"
+      - "Update check.rs to use select_review_model() (1 place)"
+      - "Update aat.rs to use select_review_model() (1 place)"
+      - "All tests pass"
+      - "No clippy warnings"

--- a/xtask/src/reviewer_state.rs
+++ b/xtask/src/reviewer_state.rs
@@ -752,6 +752,24 @@ pub fn cleanup_reviewer_temp_files(
 
 /// One hour in seconds, used as the default age threshold for orphan cleanup.
 pub const ORPHAN_CLEANUP_AGE_THRESHOLD_SECS: u64 = 3600;
+
+/// Select a review model with 50/50 distribution between pro and flash.
+///
+/// Uses the nanosecond component of the current system time to provide
+/// a roughly even distribution between the two models across invocations.
+#[must_use]
+pub fn select_review_model() -> &'static str {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    if nanos % 2 == 0 {
+        "gemini-3-pro"
+    } else {
+        "gemini-3-flash"
+    }
+}
 /// Kill a process with SIGTERM, wait up to 5s, then SIGKILL if needed.
 ///
 /// # Arguments
@@ -912,6 +930,41 @@ mod tests {
         assert_eq!(HealthStatus::Healthy.as_str(), "HEALTHY");
         assert_eq!(HealthStatus::Stale.as_str(), "STALE");
         assert_eq!(HealthStatus::Dead.as_str(), "DEAD");
+    }
+
+    #[test]
+    fn test_select_review_model_returns_valid_model() {
+        let model = select_review_model();
+        assert!(
+            model == "gemini-3-pro" || model == "gemini-3-flash",
+            "Expected 'gemini-3-pro' or 'gemini-3-flash', got '{model}'"
+        );
+    }
+
+    #[test]
+    fn test_select_review_model_distribution() {
+        // Call the function many times and verify we get both models
+        // Note: This is probabilistic but extremely unlikely to fail
+        // (probability of all same in 100 trials ≈ 2^-99)
+        let mut saw_pro = false;
+        let mut saw_flash = false;
+
+        for _ in 0..100 {
+            let model = select_review_model();
+            match model {
+                "gemini-3-pro" => saw_pro = true,
+                "gemini-3-flash" => saw_flash = true,
+                _ => panic!("Unexpected model: {model}"),
+            }
+            if saw_pro && saw_flash {
+                break;
+            }
+            // Small sleep to ensure different nanosecond values
+            std::thread::sleep(std::time::Duration::from_nanos(1));
+        }
+
+        assert!(saw_pro, "Never saw gemini-3-pro in 100 trials");
+        assert!(saw_flash, "Never saw gemini-3-flash in 100 trials");
     }
 
     #[test]

--- a/xtask/src/tasks/aat.rs
+++ b/xtask/src/tasks/aat.rs
@@ -49,6 +49,7 @@ use crate::aat::tool_config::{AatToolConfig, AiTool};
 use crate::aat::types::{Hypothesis, HypothesisResult, ParsedPRDescription, Verdict};
 use crate::aat::validation::validate_pr_description;
 use crate::aat::variation::InputVariationGenerator;
+use crate::reviewer_state::select_review_model;
 use crate::shell_escape::build_script_command;
 
 // =============================================================================
@@ -442,7 +443,7 @@ fn build_ai_script_command(prompt_path: &Path, tool_config: &AatToolConfig) -> S
     match tool_config.ai_tool {
         AiTool::Gemini => {
             // Gemini uses build_script_command from shell_escape module
-            build_script_command(prompt_path, None, Some("gemini-3-flash-preview"))
+            build_script_command(prompt_path, None, Some(select_review_model()))
         },
         AiTool::ClaudeCode => {
             // Claude Code uses similar pattern but different command

--- a/xtask/src/tasks/check.rs
+++ b/xtask/src/tasks/check.rs
@@ -26,7 +26,7 @@ use xshell::{Shell, cmd};
 use crate::reviewer_state::{
     HealthStatus, MAX_RESTART_ATTEMPTS, ORPHAN_CLEANUP_AGE_THRESHOLD_SECS, ReviewerEntry,
     ReviewerSpawner, ReviewerStateFile, acquire_remediation_lock, cleanup_reviewer_temp_files,
-    kill_process,
+    kill_process, select_review_model,
 };
 use crate::util::{current_branch, validate_ticket_branch};
 
@@ -868,7 +868,7 @@ fn restart_review(
     // Use ReviewerSpawner for centralized spawn logic
     let spawner = ReviewerSpawner::new(reviewer_type, pr_url, head_sha)
         .with_prompt_file(prompt_path_ref)?
-        .with_model("gemini-3-flash-preview")
+        .with_model(select_review_model())
         .with_restart_count(restart_count);
 
     match spawner.spawn_background() {

--- a/xtask/src/tasks/push.rs
+++ b/xtask/src/tasks/push.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 use xshell::{Shell, cmd};
 
-use crate::reviewer_state::ReviewerSpawner;
+use crate::reviewer_state::{ReviewerSpawner, select_review_model};
 use crate::util::{current_branch, main_worktree, ticket_yaml_path, validate_ticket_branch};
 
 /// Push branch and create PR.
@@ -296,7 +296,7 @@ fn trigger_ai_reviews(sh: &Shell, pr_url: &str) -> Result<()> {
         println!("  Spawning Gemini security review...");
         let spawner = ReviewerSpawner::new("security", pr_url, &head_sha)
             .with_prompt_file(Path::new(&security_prompt_path))
-            .map(|s| s.with_model("gemini-3-flash-preview"))
+            .map(|s| s.with_model(select_review_model()))
             .ok();
 
         if let Some(spawner) = spawner {
@@ -313,7 +313,7 @@ fn trigger_ai_reviews(sh: &Shell, pr_url: &str) -> Result<()> {
         println!("  Spawning Gemini code quality review...");
         let spawner = ReviewerSpawner::new("quality", pr_url, &head_sha)
             .with_prompt_file(Path::new(&code_quality_prompt_path))
-            .map(|s| s.with_model("gemini-3-flash-preview"))
+            .map(|s| s.with_model(select_review_model()))
             .ok();
 
         if let Some(spawner) = spawner {

--- a/xtask/src/tasks/review.rs
+++ b/xtask/src/tasks/review.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 use xshell::{Shell, cmd};
 
-use crate::reviewer_state::ReviewerSpawner;
+use crate::reviewer_state::{ReviewerSpawner, select_review_model};
 
 /// Review type determines which prompt and status check to use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -264,7 +264,7 @@ fn run_ai_review(
     // Use ReviewerSpawner for centralized spawn logic (synchronous mode)
     let spawner = ReviewerSpawner::new(reviewer_type_key, pr_url, head_sha)
         .with_prompt_content(&prompt)
-        .with_model("gemini-3-flash-preview");
+        .with_model(select_review_model());
 
     let status_context = review_type.status_context();
     match spawner.spawn_sync() {


### PR DESCRIPTION
## Summary

Implements ticket TCK-00278 as part of the xtask development automation.

## Ticket

See `documents/work/tickets/TCK-00278.yaml` for requirements.

## Test Plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test -p xtask` passes
- [ ] Manual testing of the new command
