### PR TITLE
TCK-00686: fix(TCK-00686): preserve sqlite intent enqueue order in shared runtime

### DIFF
--- a/crates/apm2-cli/src/commands/fac_review/repair_cycle.rs
+++ b/crates/apm2-cli/src/commands/fac_review/repair_cycle.rs
@@ -288,6 +288,17 @@ fn execute_strategy(
     match strategy {
         RepairStrategy::Noop => Ok((None, None)),
         RepairStrategy::DispatchRepair => {
+            let projection_repair = lifecycle::reconcile_projection_gap_for_head(
+                &ctx.owner_repo,
+                ctx.pr_number,
+                &ctx.head_sha,
+                "doctor_fix_projection_gap",
+            )?;
+
+            if projection_repair.converged() {
+                return Ok((None, None));
+            }
+
             let reviews = dispatch_reviews(
                 &ctx.owner_repo,
                 ctx.pr_number,

--- a/crates/apm2-daemon/src/gate/AGENTS.json
+++ b/crates/apm2-daemon/src/gate/AGENTS.json
@@ -115,6 +115,27 @@
       "kind": "safety",
       "title": "parse_gate_lease_payload validates payload size and calls GateLease::validate() after deserialization",
       "rfc": ["RFC-0020"]
+    },
+    {
+      "id": "BEH-DAEMON-GATE-020",
+      "kind": "invariant",
+      "title": "GateStart ledger tailing delegates to shared ledger_poll (no bespoke canonical+legacy merge)",
+      "description": "SqliteGateStartLedgerReader MUST call crates/apm2-daemon/src/ledger_poll.rs (`poll_events_async`/`poll_events_blocking`) for cursor-safe canonical+legacy reads. Hand-rolled merge SQL in gate-start is forbidden.",
+      "rfc": ["RFC-0020", "RFC-0032"]
+    },
+    {
+      "id": "BEH-DAEMON-GATE-021",
+      "kind": "invariant",
+      "title": "GateStart durable cursor/intent/effect state uses orchestrator_runtime shared tables",
+      "description": "GateStartKernel stores cursor, intent buffer, and effect journal via orchestrator_runtime adapters keyed by orchestrator_id `gate_start_kernel` (tables: orchestrator_kernel_cursors, orchestrator_kernel_intents, orchestrator_kernel_effect_journal).",
+      "rfc": ["RFC-0020", "RFC-0032"]
+    },
+    {
+      "id": "BEH-DAEMON-GATE-022",
+      "kind": "safety",
+      "title": "GateStart legacy storage migration is one-time, idempotent, and fail-closed",
+      "description": "Legacy gate-start artifacts (`gate_start_kernel_cursor`, `gate_start_intents`, `gate_start_effect_journal.sqlite`) are migrated into shared orchestrator_runtime tables only when the target namespace is empty. Legacy effect states `started/unknown` map to `unknown` to preserve fail-closed semantics.",
+      "rfc": ["RFC-0020", "RFC-0032"]
     }
   ]
 }

--- a/crates/apm2-daemon/src/main.rs
+++ b/crates/apm2-daemon/src/main.rs
@@ -1468,13 +1468,14 @@ async fn async_main(args: Args) -> Result<()> {
                 }
                 emitter
             });
-        let gate_start_kernel = GateStartKernel::new(
+        let gate_start_kernel = GateStartKernel::new_async(
             Arc::clone(&orch),
             sqlite_conn.as_ref(),
             gate_start_ledger_emitter,
             &fac_root,
             GateStartKernelConfig::default(),
         )
+        .await
         .map_err(|e| anyhow::anyhow!("failed to initialize gate start kernel: {e}"))?;
         let timeout_kernel = GateTimeoutKernel::new_async(
             Arc::clone(&orch),

--- a/crates/apm2-daemon/src/orchestrator_runtime/AGENTS.json
+++ b/crates/apm2-daemon/src/orchestrator_runtime/AGENTS.json
@@ -23,13 +23,13 @@
     {
       "id": "BEH-DAEMON-OKRT-004",
       "kind": "invariant",
-      "title": "Intent dequeue ordered by (created_at_ns ASC, intent_key ASC) for FIFO",
+      "title": "Intent enqueue assigns strictly increasing created_at_ns and dequeue orders by (created_at_ns ASC, rowid ASC) to preserve enqueue order",
       "rfc": ["RFC-0020"]
     },
     {
       "id": "BEH-DAEMON-OKRT-005",
       "kind": "invariant",
-      "title": "mark_retryable sets created_at_ns = now to move intent to back of queue",
+      "title": "mark_retryable assigns tail created_at_ns based on MAX(created_at_ns)+1 to move intent to queue back deterministically",
       "rfc": ["RFC-0020"]
     },
     {

--- a/crates/apm2-daemon/tests/hef_fac_vnext_changeset_identity_e2e.rs
+++ b/crates/apm2-daemon/tests/hef_fac_vnext_changeset_identity_e2e.rs
@@ -221,13 +221,14 @@ async fn hef_fac_vnext_changeset_identity_e2e() {
         Arc::new(Signer::generate()),
     ));
     let fac_root = TempDir::new().expect("create temp fac root");
-    let mut gate_start_kernel = GateStartKernel::new(
+    let mut gate_start_kernel = GateStartKernel::new_async(
         Arc::clone(&gate_orchestrator),
         Some(&sqlite),
         Some(kernel_emitter),
         fac_root.path(),
         GateStartKernelConfig::default(),
     )
+    .await
     .expect("create gate start kernel");
 
     let work_id = "W-hef-fac-vnext-csid-e2e";

--- a/documents/architecture/orchestrator_kernel.md
+++ b/documents/architecture/orchestrator_kernel.md
@@ -1,0 +1,96 @@
+title: OrchestratorKernel Architecture Doctrine
+status: active
+
+## Purpose
+
+This document defines the required architecture for APM2 orchestrators that tail
+ledger events and produce durable effects/receipts.
+
+The canonical control-loop shape is:
+
+`Observe -> Plan -> Execute -> Receipt`
+
+Implemented by `apm2_core::orchestrator_kernel`.
+
+## Kernel Contract
+
+1. `LedgerReader` is the authoritative read boundary for ordered observations.
+2. `OrchestratorDomain` is deterministic and pure with respect to observed data.
+3. `EffectJournal` enforces idempotent effect execution and fail-closed
+   `resolve_in_doubt` behavior.
+4. `CursorStore` advances only after durable receipt persistence for the same
+   observation span.
+5. `TickConfig` bounds per-tick observe/execute work.
+
+## Cursor Doctrine
+
+Cursor type is ledger-specific and must match ledger ordering truth.
+
+- Use `KernelCursor` (total order required).
+- `CompositeCursor` is valid for `(timestamp_ns, event_id)` ledgers.
+- Sequence/commit-index cursors are preferred when the ledger is sequence-native.
+- Kernel consumers must not assume timestamp cursors by default.
+
+## Daemon Storage Doctrine
+
+Daemon orchestrators must use `crates/apm2-daemon/src/orchestrator_runtime`:
+
+- `SqliteCursorStore` -> `orchestrator_kernel_cursors`
+- `SqliteIntentStore` -> `orchestrator_kernel_intents`
+- `SqliteEffectJournal` -> `orchestrator_kernel_effect_journal`
+
+All adapters are keyed by stable `orchestrator_id`.
+
+Per-orchestrator sqlite tables/files for cursor/intent/effect-journal concerns are
+forbidden.
+
+## Ledger Polling Doctrine
+
+Any canonical+legacy merge read must use
+`crates/apm2-daemon/src/ledger_poll.rs`.
+
+Required helpers:
+
+- `canonical_event_id(seq_id) -> canonical-{seq_id:020}`
+- `poll_events_blocking(...)`
+- `poll_events_async(...)`
+
+Hand-rolled merge SQL in orchestrators is forbidden.
+
+## Time Doctrine
+
+Monotonic timestamps (`Instant`-derived values) are process-local and not durable
+truth.
+
+If monotonic values are persisted for cache performance, they must be rebased on
+load using wall-clock authority before any irreversible action.
+
+Reference implementation:
+`crates/apm2-daemon/src/gate/timeout_kernel.rs` (`ObservedLeaseState::rebase`).
+
+## CAS and Ledger Composition
+
+- Large payloads belong in CAS.
+- Ledger events/intents carry stable references (digest/id), not full mutable
+  payload copies.
+- Receipt verification and evidence anchoring happen before cursor advancement.
+
+## Migration Pattern for Existing Loops
+
+1. Model existing loop as `OrchestratorDomain`.
+2. Lift poller to `ledger_poll` helper.
+3. Replace local cursor/intent/effect storage with orchestrator_runtime adapters.
+4. Add one-time idempotent migration from legacy storage artifacts.
+5. Add replay/idempotency tests and malformed-row progress tests.
+
+## Grep Anchors for Review
+
+- `run_tick`
+- `LedgerReader`
+- `orchestrator_runtime`
+- `orchestrator_kernel_cursors`
+- `orchestrator_kernel_intents`
+- `orchestrator_kernel_effect_journal`
+- `poll_events_async`
+- `canonical_event_id`
+- `MONO_EPOCH`

--- a/documents/prompts/instruction.alien_coding.v1.json
+++ b/documents/prompts/instruction.alien_coding.v1.json
@@ -522,6 +522,31 @@
                 "Replace scattered `validate/verify/is_valid` checks and boolean flags with boundary parsing into domain types (newtypes/enums/NonEmpty/Bounded). Make illegal states unrepresentable in State/Input/Effect."
             ]
         },
+        "orchestrator_kernel_doctrine": {
+            "scope": "Any orchestration loop that tails the ledger incrementally, plans intents, executes effects, and emits receipts.",
+            "mandatory_path": [
+                "MUST use apm2_core::orchestrator_kernel for the Observe->Plan->Execute->Receipt control loop.",
+                "Daemon implementations MUST use crates/apm2-daemon/src/orchestrator_runtime adapters for durable cursor, intent, and effect-journal storage.",
+                "MUST use crates/apm2-daemon/src/ledger_poll.rs for canonical+legacy merge polling and canonical event-id synthesis."
+            ],
+            "required_design_inputs": [
+                "Choose and document the KernelCursor type matching ledger ordering truth (CompositeCursor, sequence cursor, commit index cursor, etc.).",
+                "Declare a stable orchestrator_id constant; durability is keyed by orchestrator_id and changing it discards durable state continuity.",
+                "Define receipt/effect idempotency keys as pure functions of authoritative input references."
+            ],
+            "forbidden_patterns": [
+                "No bespoke observe/plan/execute/receipt loops outside orchestrator_kernel.",
+                "No per-orchestrator sqlite tables or sqlite sidecar files for cursor/intent/effect journal concerns.",
+                "No blocking rusqlite calls directly on async paths; use spawn_blocking or async wrappers only.",
+                "No persisted monotonic timestamps treated as durable authority truth. If cached durably, they MUST be rebased on load before decisions."
+            ],
+            "review_anchors": [
+                "run_tick, LedgerReader, OrchestratorDomain, ReceiptWriter",
+                "orchestrator_kernel_cursors, orchestrator_kernel_intents, orchestrator_kernel_effect_journal",
+                "poll_events_blocking, poll_events_async, canonical_event_id",
+                "observed_monotonic_ns, deadline_monotonic_ns, MONO_EPOCH, Instant::now"
+            ]
+        },
         "review_lenses": {
             "lens_1_state_is_sufficient_statistic": [
                 "Each State field has a justification as sufficient statistic.",

--- a/documents/reviews/CODE_QUALITY_PROMPT.cac.json
+++ b/documents/reviews/CODE_QUALITY_PROMPT.cac.json
@@ -100,6 +100,16 @@
         }
       ]
     },
+    "review_checklist": {
+      "title": "Orchestrator Kernel Doctrine Checklist",
+      "items": [
+        "If the PR adds a ledger-tailing control loop, verify it uses apm2_core::orchestrator_kernel (`run_tick`, `LedgerReader`, `OrchestratorDomain`, `ReceiptWriter`).",
+        "Reject new per-orchestrator sqlite tables/files for cursor/intent/effect journal concerns. Grep: `CREATE TABLE IF NOT EXISTS .*_cursor`, `CREATE TABLE IF NOT EXISTS .*_intent`, `effect_journal`, `Connection::open(`.",
+        "For daemon async paths, verify every rusqlite call is offloaded via `spawn_blocking` or adapter wrappers.",
+        "If code merges `ledger_events` + `events`, verify usage of `crates/apm2-daemon/src/ledger_poll.rs` and `canonical_event_id` helper.",
+        "For persisted monotonic values, verify explicit rebase-on-load before irreversible decisions. Grep: `observed_monotonic_ns`, `deadline_monotonic_ns`, `MONO_EPOCH`, `Instant::now`."
+      ]
+    },
     "references": [
       {"path": "@documents/theory/unified-theory-v2.json", "purpose": "Holonic model, truth/projection split, and verification-first behavior."},
       {"path": "@AGENTS.md", "purpose": "Global repository instructions."},

--- a/documents/skills/rust-standards/references/41_apm2_safe_patterns_and_anti_patterns.md
+++ b/documents/skills/rust-standards/references/41_apm2_safe_patterns_and_anti_patterns.md
@@ -1,0 +1,81 @@
+title: 41. APM2 Safe Patterns and Anti-Patterns
+
+## Safe Pattern: Kernelized Orchestrator Loop
+
+Use `apm2_core::orchestrator_kernel` for all ledger-tailing orchestration loops.
+
+Checklist:
+
+- `LedgerReader` returns events ordered by the selected `KernelCursor`.
+- `CursorStore` durability is keyed by stable `orchestrator_id`.
+- `IntentStore` is idempotent (`INSERT OR IGNORE` semantics).
+- `EffectJournal` enforces fail-closed ambiguity handling (`resolve_in_doubt`).
+- Cursor is persisted only after receipt durability.
+
+Preferred daemon adapters:
+
+- `crates/apm2-daemon/src/orchestrator_runtime/sqlite.rs`
+- Tables: `orchestrator_kernel_cursors`, `orchestrator_kernel_intents`,
+  `orchestrator_kernel_effect_journal`.
+
+## Safe Pattern: Shared Freeze-Aware Polling
+
+Use `crates/apm2-daemon/src/ledger_poll.rs` for any merge of legacy
+`ledger_events` and canonical `events`.
+
+Required helpers:
+
+- `canonical_event_id(seq_id)` (zero-padded lexical ordering)
+- `poll_events_blocking(...)`
+- `poll_events_async(...)`
+
+## Anti-Pattern: Bespoke Orchestration Loop
+
+Do not implement ad-hoc observe/plan/execute/receipt loops that bypass
+`orchestrator_kernel`.
+
+Why this is unsafe:
+
+- Inconsistent idempotency windows.
+- Cursor advancement race windows.
+- Divergent fail-closed behavior across orchestrators.
+
+## Anti-Pattern: Per-Orchestrator SQLite Stores
+
+Do not create new tables/files such as:
+
+- `*_cursor`
+- `*_intent*`
+- custom `*_effect_journal*.sqlite`
+
+Use shared runtime adapters keyed by `orchestrator_id` instead.
+
+## Anti-Pattern: Blocking SQLite in Async Paths
+
+Do not run `rusqlite` directly on tokio async execution paths.
+
+Use `spawn_blocking` wrappers provided by runtime adapters/pollers.
+
+## Anti-Pattern: Persisted Monotonic as Durable Truth
+
+`Instant`/monotonic timestamps are process-local and reset on restart.
+
+Do not trigger irreversible decisions from persisted monotonic values without
+rebase-on-load against wall-clock authority.
+
+Reference grep anchors:
+
+- `observed_monotonic_ns`
+- `deadline_monotonic_ns`
+- `MONO_EPOCH`
+- `Instant::now`
+
+## Reviewer Quick Anchors
+
+- `run_tick`
+- `orchestrator_runtime`
+- `ledger_poll`
+- `canonical_event_id`
+- `orchestrator_kernel_cursors`
+- `orchestrator_kernel_intents`
+- `orchestrator_kernel_effect_journal`


### PR DESCRIPTION
```yaml
schema: apm2.fac_push_metadata.v1
work_id: W-TCK-00686
ticket_alias: TCK-00686
branch: ticket/RFC-0032/TCK-00686
fac_push_metadata:
  commit_history:
  - short_sha: 8fdb8393
    message: 'feat(TCK-00686): kernelize gate-start runtime and codify doctrine'
  - short_sha: cc312edf
    message: 'fix(TCK-00686): satisfy clippy gate in gate-start wiring'
  - short_sha: 3361f935
    message: 'fix(TCK-00686): converge doctor projection-gap repair and local-first merge'
  - short_sha: 1a9be471
    message: 'fix(TCK-00686): preserve sqlite intent enqueue order in shared runtime'
```

<!-- apm2-gate-status:start -->
## FAC Gate Status

```yaml
# apm2-gate-status:v2
sha: 1a9be4717fd0ba5fd28502016576bb79d9c1fe7d
short_sha: 1a9be471
timestamp: '2026-02-25T19:12:54Z'
all_passed: true
gates:
  - name: 'merge_conflict_main'
    status: PASS
    duration_secs: 0
  - name: 'review_artifact_lint'
    status: PASS
    duration_secs: 0
  - name: 'rustfmt'
    status: PASS
    duration_secs: 2
  - name: 'doc'
    status: PASS
    duration_secs: 0
  - name: 'clippy'
    status: PASS
    duration_secs: 31
  - name: 'test_safety_guard'
    status: PASS
    duration_secs: 0
  - name: 'fac_review_machine_spec_snapshot'
    status: PASS
    duration_secs: 0
  - name: 'test'
    status: PASS
    duration_secs: 72
  - name: 'workspace_integrity'
    status: PASS
    duration_secs: 0
```
<!-- apm2-gate-status:end -->
