### PR TITLE
TCK-00687: gate-timeout: satisfy clippy by tightening tick helpers

### DIFF
--- a/crates/apm2-daemon/src/gate/AGENTS.json
+++ b/crates/apm2-daemon/src/gate/AGENTS.json
@@ -136,6 +136,13 @@
       "title": "GateStart legacy storage migration is one-time, idempotent, and fail-closed",
       "description": "Legacy gate-start artifacts (`gate_start_kernel_cursor`, `gate_start_intents`, `gate_start_effect_journal.sqlite`) are migrated into shared orchestrator_runtime tables only when the target namespace is empty. Legacy effect states `started/unknown` map to `unknown` to preserve fail-closed semantics.",
       "rfc": ["RFC-0020", "RFC-0032"]
+    },
+    {
+      "id": "BEH-DAEMON-GATE-023",
+      "kind": "invariant",
+      "title": "GateTimeoutDomain apply_events/plan are pure and persist observed-lease cache only in checkpoint before cursor advance",
+      "description": "GateTimeoutKernel uses `OrchestratorDomain::checkpoint` to flush observed-lease upserts/removals. `apply_events` and `plan` mutate in-memory state only, preserving deterministic replay semantics and explicit durability ordering.",
+      "rfc": ["RFC-0020", "RFC-0032"]
     }
   ]
 }

--- a/crates/apm2-daemon/src/gate/timeout_kernel.rs
+++ b/crates/apm2-daemon/src/gate/timeout_kernel.rs
@@ -4,7 +4,7 @@
 //! shared `apm2_core::orchestrator_kernel` harness:
 //! Observe -> Plan -> Execute -> Receipt.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
@@ -31,6 +31,34 @@ use crate::protocol::dispatch::LedgerEventEmitter;
 
 const TIMEOUT_PERSISTOR_SESSION_ID: &str = "gate-timeout-poller";
 const TIMEOUT_PERSISTOR_ACTOR_ID: &str = "orchestrator:timeout-poller";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TimeoutTickNow {
+    wall_ms: u64,
+    monotonic_ns: u64,
+}
+
+impl TimeoutTickNow {
+    fn capture() -> Result<Self, String> {
+        Ok(Self {
+            wall_ms: epoch_now_ms_u64(),
+            monotonic_ns: monotonic_now_ns()?,
+        })
+    }
+}
+
+trait TimeoutTickClock: Send + Sync + std::fmt::Debug {
+    fn now(&self) -> Result<TimeoutTickNow, String>;
+}
+
+#[derive(Debug, Default)]
+struct SystemTimeoutTickClock;
+
+impl TimeoutTickClock for SystemTimeoutTickClock {
+    fn now(&self) -> Result<TimeoutTickNow, String> {
+        TimeoutTickNow::capture()
+    }
+}
 
 /// Kernel configuration for gate-timeout orchestration ticks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,6 +102,7 @@ pub struct GateTimeoutKernel {
     effect_journal: TimeoutEffectJournalEnum,
     receipt_writer: GateTimeoutReceiptWriter,
     tick_config: TickConfig,
+    tick_clock: Arc<dyn TimeoutTickClock>,
 }
 
 /// Dispatch enum for cursor store: `SQLite` (shared) or Memory.
@@ -343,11 +372,17 @@ impl GateTimeoutKernel {
                 observe_limit: config.observe_limit,
                 execute_limit: config.execute_limit,
             },
+            tick_clock: Arc::new(SystemTimeoutTickClock),
         })
     }
 
     /// Runs one timeout-kernel tick.
     pub async fn tick(&mut self) -> Result<TickReport, GateTimeoutKernelError> {
+        let tick_now = self
+            .tick_clock
+            .now()
+            .map_err(|e| GateTimeoutKernelError::Tick(format!("tick clock failure: {e}")))?;
+        self.domain.set_tick_now(tick_now);
         run_tick(
             &mut self.domain,
             &self.ledger_reader,
@@ -1164,6 +1199,9 @@ struct GateTimeoutDomain {
     observed_leases: HashMap<String, ObservedLeaseState>,
     observed_lease_store: TimeoutObservedLeaseStore,
     terminal_checker: TimeoutTerminalChecker,
+    dirty_upserts: HashMap<String, ObservedLeaseState>,
+    dirty_removals: HashSet<String>,
+    tick_now: Option<TimeoutTickNow>,
 }
 
 impl GateTimeoutDomain {
@@ -1178,7 +1216,31 @@ impl GateTimeoutDomain {
             observed_leases,
             observed_lease_store,
             terminal_checker,
+            dirty_upserts: HashMap::new(),
+            dirty_removals: HashSet::new(),
+            tick_now: Some(TimeoutTickNow::capture()?),
         })
+    }
+
+    fn set_tick_now(&mut self, tick_now: TimeoutTickNow) {
+        self.tick_now = Some(tick_now);
+    }
+
+    fn require_tick_now(&self) -> Result<TimeoutTickNow, String> {
+        self.tick_now.ok_or_else(|| {
+            "timeout tick context missing; set tick snapshot before apply/plan".to_string()
+        })
+    }
+
+    fn mark_dirty_upsert(&mut self, state: &ObservedLeaseState) {
+        let lease_id = state.lease.lease_id.clone();
+        self.dirty_removals.remove(&lease_id);
+        self.dirty_upserts.insert(lease_id, state.clone());
+    }
+
+    fn mark_dirty_remove(&mut self, lease_id: &str) {
+        self.dirty_upserts.remove(lease_id);
+        self.dirty_removals.insert(lease_id.to_string());
     }
 
     /// Synchronous variant kept for potential non-async callers.
@@ -1193,24 +1255,8 @@ impl GateTimeoutDomain {
             .map(|(lease_id, _)| lease_id.clone())
             .collect();
         for lease_id in lease_ids {
-            self.observed_lease_store.remove(&lease_id)?;
             self.observed_leases.remove(&lease_id);
-        }
-        Ok(())
-    }
-
-    /// Async variant of [`Self::remove_work_leases`] that uses
-    /// `remove_async` to offload `SQLite` I/O per `INV-CQ-OK-003`.
-    async fn remove_work_leases_async(&mut self, work_id: &str) -> Result<(), String> {
-        let lease_ids: Vec<String> = self
-            .observed_leases
-            .iter()
-            .filter(|(_, state)| state.lease.work_id == work_id)
-            .map(|(lease_id, _)| lease_id.clone())
-            .collect();
-        for lease_id in lease_ids {
-            self.observed_lease_store.remove_async(&lease_id).await?;
-            self.observed_leases.remove(&lease_id);
+            self.mark_dirty_remove(&lease_id);
         }
         Ok(())
     }
@@ -1226,27 +1272,27 @@ impl OrchestratorDomain<TimeoutObservedEvent, GateTimeoutIntent, String, GateOrc
     }
 
     async fn apply_events(&mut self, events: &[TimeoutObservedEvent]) -> Result<(), Self::Error> {
+        let tick_now = self.require_tick_now()?;
         for event in events {
             match &event.kind {
                 TimeoutObservedKind::LeaseIssued { lease, gate_type } => {
-                    let observed_wall_ms = self.orchestrator.now_ms();
-                    let observed_monotonic_ns = monotonic_now_ns()?;
                     let state = ObservedLeaseState::from_observation(
                         lease.as_ref(),
                         *gate_type,
-                        observed_wall_ms,
-                        observed_monotonic_ns,
+                        tick_now.wall_ms,
+                        tick_now.monotonic_ns,
                     );
-                    self.observed_lease_store.upsert_async(&state).await?;
-                    self.observed_leases.insert(lease.lease_id.clone(), state);
+                    self.observed_leases
+                        .insert(lease.lease_id.clone(), state.clone());
+                    self.mark_dirty_upsert(&state);
                 },
                 TimeoutObservedKind::GateReceiptFinalized { lease_id }
                 | TimeoutObservedKind::TimedOut { lease_id } => {
-                    self.observed_lease_store.remove_async(lease_id).await?;
                     self.observed_leases.remove(lease_id);
+                    self.mark_dirty_remove(lease_id);
                 },
                 TimeoutObservedKind::AllCompleted { work_id } => {
-                    self.remove_work_leases_async(work_id).await?;
+                    self.remove_work_leases(work_id)?;
                 },
                 TimeoutObservedKind::Skipped { .. } => {
                     // Intentionally ignored -- the event exists only to
@@ -1258,8 +1304,9 @@ impl OrchestratorDomain<TimeoutObservedEvent, GateTimeoutIntent, String, GateOrc
     }
 
     async fn plan(&mut self) -> Result<Vec<GateTimeoutIntent>, Self::Error> {
-        let monotonic_now_ns = monotonic_now_ns()?;
-        let now_wall_ms = epoch_now_ms_u64();
+        let tick_now = self.require_tick_now()?;
+        let monotonic_now_ns = tick_now.monotonic_ns;
+        let now_wall_ms = tick_now.wall_ms;
 
         // Guard: scan for stale/corrupt monotonic entries and rebase them
         // before generating timeout intents. This prevents a long-running
@@ -1271,10 +1318,10 @@ impl OrchestratorDomain<TimeoutObservedEvent, GateTimeoutIntent, String, GateOrc
             .map(|(key, _)| key.clone())
             .collect();
         for key in &stale_keys {
-            if let Some(state) = self.observed_leases.get(key) {
+            if let Some(state) = self.observed_leases.get(key).cloned() {
                 let rebased = state.rebase(now_wall_ms, monotonic_now_ns);
-                self.observed_lease_store.upsert_async(&rebased).await?;
-                self.observed_leases.insert(key.clone(), rebased);
+                self.observed_leases.insert(key.clone(), rebased.clone());
+                self.mark_dirty_upsert(&rebased);
             }
         }
 
@@ -1289,6 +1336,24 @@ impl OrchestratorDomain<TimeoutObservedEvent, GateTimeoutIntent, String, GateOrc
             .collect();
         timed_out.sort_by(|a, b| a.lease.lease_id.cmp(&b.lease.lease_id));
         Ok(timed_out)
+    }
+
+    async fn checkpoint(&mut self) -> Result<(), Self::Error> {
+        let mut upserts: Vec<ObservedLeaseState> = self.dirty_upserts.values().cloned().collect();
+        upserts.sort_by(|a, b| a.lease.lease_id.cmp(&b.lease.lease_id));
+        for state in &upserts {
+            self.observed_lease_store.upsert_async(state).await?;
+        }
+
+        let mut removals: Vec<String> = self.dirty_removals.iter().cloned().collect();
+        removals.sort();
+        for lease_id in &removals {
+            self.observed_lease_store.remove_async(lease_id).await?;
+        }
+
+        self.dirty_upserts.clear();
+        self.dirty_removals.clear();
+        Ok(())
     }
 
     async fn execute(
@@ -2743,6 +2808,142 @@ mod tests {
         assert!(
             planned.is_empty(),
             "completed gate lease must not produce timeout intents"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_events_uses_injected_tick_snapshot_for_observation_baseline() {
+        let orchestrator = Arc::new(GateOrchestrator::new(
+            crate::gate::GateOrchestratorConfig::default(),
+            Arc::new(Signer::generate()),
+        ));
+        let mut domain = GateTimeoutDomain::new(
+            Arc::clone(&orchestrator),
+            TimeoutObservedLeaseStore::Memory(MemoryTimeoutObservedLeaseStore::default()),
+            TimeoutTerminalChecker::Memory(MemoryTimeoutTerminalChecker),
+        )
+        .expect("domain initialization should succeed");
+
+        let tick_now = TimeoutTickNow {
+            wall_ms: 50_000,
+            monotonic_ns: 9_000,
+        };
+        domain.set_tick_now(tick_now);
+
+        let lease = sample_gate_lease("lease-tick-snapshot-1", 50_123);
+        domain
+            .apply_events(&[TimeoutObservedEvent {
+                timestamp_ns: 1,
+                event_id: "evt-lease".to_string(),
+                kind: TimeoutObservedKind::LeaseIssued {
+                    lease: Box::new(lease.clone()),
+                    gate_type: GateType::Quality,
+                },
+            }])
+            .await
+            .expect("apply_events should succeed");
+
+        let state = domain
+            .observed_leases
+            .get(&lease.lease_id)
+            .expect("lease state should be tracked");
+        assert_eq!(state.observed_wall_ms, tick_now.wall_ms);
+        assert_eq!(state.observed_monotonic_ns, tick_now.monotonic_ns);
+        assert_eq!(
+            state.deadline_monotonic_ns,
+            tick_now
+                .monotonic_ns
+                .saturating_add(123_u64.saturating_mul(1_000_000))
+        );
+    }
+
+    #[tokio::test]
+    async fn observed_lease_persistence_is_deferred_until_checkpoint() {
+        let orchestrator = Arc::new(GateOrchestrator::new(
+            crate::gate::GateOrchestratorConfig::default(),
+            Arc::new(Signer::generate()),
+        ));
+        let memory_store = MemoryTimeoutObservedLeaseStore::default();
+        let mut domain = GateTimeoutDomain::new(
+            Arc::clone(&orchestrator),
+            TimeoutObservedLeaseStore::Memory(memory_store.clone()),
+            TimeoutTerminalChecker::Memory(MemoryTimeoutTerminalChecker),
+        )
+        .expect("domain initialization should succeed");
+        domain.set_tick_now(TimeoutTickNow {
+            wall_ms: 60_000,
+            monotonic_ns: 12_000,
+        });
+
+        let lease = sample_gate_lease("lease-checkpoint-1", 61_000);
+        domain
+            .apply_events(&[TimeoutObservedEvent {
+                timestamp_ns: 1,
+                event_id: "evt-issued".to_string(),
+                kind: TimeoutObservedKind::LeaseIssued {
+                    lease: Box::new(lease.clone()),
+                    gate_type: GateType::Quality,
+                },
+            }])
+            .await
+            .expect("apply_events should succeed");
+
+        let before_checkpoint = memory_store
+            .load_all()
+            .expect("memory store load should succeed before checkpoint");
+        assert!(
+            before_checkpoint.is_empty(),
+            "apply_events must not persist observed leases before checkpoint"
+        );
+
+        let _planned = domain.plan().await.expect("plan should succeed");
+        let still_before = memory_store
+            .load_all()
+            .expect("memory store load should succeed before checkpoint");
+        assert!(
+            still_before.is_empty(),
+            "plan must not persist observed leases before checkpoint"
+        );
+
+        domain
+            .checkpoint()
+            .await
+            .expect("checkpoint should persist dirty observed leases");
+        let after_checkpoint = memory_store
+            .load_all()
+            .expect("memory store load should succeed after checkpoint");
+        assert_eq!(after_checkpoint.len(), 1);
+        assert!(after_checkpoint.contains_key(&lease.lease_id));
+
+        domain
+            .apply_events(&[TimeoutObservedEvent {
+                timestamp_ns: 2,
+                event_id: "evt-complete".to_string(),
+                kind: TimeoutObservedKind::GateReceiptFinalized {
+                    lease_id: lease.lease_id.clone(),
+                },
+            }])
+            .await
+            .expect("apply_events remove should succeed");
+
+        let before_remove_checkpoint = memory_store
+            .load_all()
+            .expect("memory store load should succeed before remove checkpoint");
+        assert!(
+            before_remove_checkpoint.contains_key(&lease.lease_id),
+            "removal must not persist before checkpoint"
+        );
+
+        domain
+            .checkpoint()
+            .await
+            .expect("checkpoint should flush removals");
+        let after_remove_checkpoint = memory_store
+            .load_all()
+            .expect("memory store load should succeed after remove checkpoint");
+        assert!(
+            !after_remove_checkpoint.contains_key(&lease.lease_id),
+            "lease should be removed after checkpoint flush"
         );
     }
 

--- a/crates/apm2-daemon/src/gate/timeout_kernel.rs
+++ b/crates/apm2-daemon/src/gate/timeout_kernel.rs
@@ -1222,7 +1222,7 @@ impl GateTimeoutDomain {
         })
     }
 
-    fn set_tick_now(&mut self, tick_now: TimeoutTickNow) {
+    const fn set_tick_now(&mut self, tick_now: TimeoutTickNow) {
         self.tick_now = Some(tick_now);
     }
 
@@ -1247,7 +1247,7 @@ impl GateTimeoutDomain {
     /// Production async callers should prefer
     /// [`Self::remove_work_leases_async`].
     #[allow(dead_code)]
-    fn remove_work_leases(&mut self, work_id: &str) -> Result<(), String> {
+    fn remove_work_leases(&mut self, work_id: &str) {
         let lease_ids: Vec<String> = self
             .observed_leases
             .iter()
@@ -1258,7 +1258,6 @@ impl GateTimeoutDomain {
             self.observed_leases.remove(&lease_id);
             self.mark_dirty_remove(&lease_id);
         }
-        Ok(())
     }
 }
 
@@ -1292,7 +1291,7 @@ impl OrchestratorDomain<TimeoutObservedEvent, GateTimeoutIntent, String, GateOrc
                     self.mark_dirty_remove(lease_id);
                 },
                 TimeoutObservedKind::AllCompleted { work_id } => {
-                    self.remove_work_leases(work_id)?;
+                    self.remove_work_leases(work_id);
                 },
                 TimeoutObservedKind::Skipped { .. } => {
                     // Intentionally ignored -- the event exists only to

--- a/documents/reviews/CODE_QUALITY_PROMPT.cac.json
+++ b/documents/reviews/CODE_QUALITY_PROMPT.cac.json
@@ -97,6 +97,11 @@
           "id": "INV-CQ-OK-005",
           "description": "Any code that merges canonical `events` and legacy `ledger_events` tables MUST use the shared poller module (crates/apm2-daemon/src/ledger_poll.rs). Hand-rolled SQL that unions or interleaves both tables is a MAJOR finding. Grep anchors: ledger_events, canonical.*events, poll_events.",
           "criticality": "CORRECTNESS"
+        },
+        {
+          "id": "INV-CQ-OK-006",
+          "description": "In `OrchestratorDomain` implementations, `apply_events` and `plan` MUST remain deterministic and free of durable store I/O side effects. Durable domain-cache persistence MUST occur in an explicit `checkpoint` phase before cursor save. Any sqlite writes/reads (upsert/remove/query/execute) in `apply_events`/`plan` are a MAJOR finding. Grep anchors: `impl OrchestratorDomain`, `apply_events(`, `plan(`, `checkpoint(`, `upsert_async`, `remove_async`, `query_row`, `execute`.",
+          "criticality": "CORRECTNESS"
         }
       ]
     },
@@ -107,6 +112,7 @@
         "Reject new per-orchestrator sqlite tables/files for cursor/intent/effect journal concerns. Grep: `CREATE TABLE IF NOT EXISTS .*_cursor`, `CREATE TABLE IF NOT EXISTS .*_intent`, `effect_journal`, `Connection::open(`.",
         "For daemon async paths, verify every rusqlite call is offloaded via `spawn_blocking` or adapter wrappers.",
         "If code merges `ledger_events` + `events`, verify usage of `crates/apm2-daemon/src/ledger_poll.rs` and `canonical_event_id` helper.",
+        "For `OrchestratorDomain` implementations, verify `apply_events`/`plan` are pure (no durable store I/O) and that checkpoint persistence happens before cursor advance.",
         "For persisted monotonic values, verify explicit rebase-on-load before irreversible decisions. Grep: `observed_monotonic_ns`, `deadline_monotonic_ns`, `MONO_EPOCH`, `Instant::now`."
       ]
     },


### PR DESCRIPTION
```yaml
schema: apm2.fac_push_metadata.v1
work_id: W-TCK-00687
ticket_alias: TCK-00687
branch: ticket/RFC-0032/TCK-00687
fac_push_metadata:
  commit_history:
  - short_sha: 89deeaa7
    message: 'orchestrator-kernel: add checkpoint phase and pure timeout planning'
  - short_sha: c8a0597b
    message: 'gate-timeout: satisfy clippy by tightening tick helpers'
```

<!-- apm2-gate-status:start -->
## FAC Gate Status

```yaml
# apm2-gate-status:v2
sha: c8a0597b9bc2903dc54c47bc0adf121eb3b5498c
short_sha: c8a0597b
timestamp: '2026-02-25T20:00:25Z'
all_passed: true
gates:
  - name: 'merge_conflict_main'
    status: PASS
    duration_secs: 0
  - name: 'review_artifact_lint'
    status: PASS
    duration_secs: 0
  - name: 'rustfmt'
    status: PASS
    duration_secs: 3
  - name: 'doc'
    status: PASS
    duration_secs: 0
  - name: 'clippy'
    status: PASS
    duration_secs: 40
  - name: 'test_safety_guard'
    status: PASS
    duration_secs: 0
  - name: 'fac_review_machine_spec_snapshot'
    status: PASS
    duration_secs: 0
  - name: 'test'
    status: PASS
    duration_secs: 126
  - name: 'workspace_integrity'
    status: PASS
    duration_secs: 0
```
<!-- apm2-gate-status:end -->
